### PR TITLE
Fix UI bugs and workout day label

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/screens/AddExerciseScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/AddExerciseScreen.kt
@@ -93,43 +93,45 @@ fun AddExerciseScreen(
                     }
                 }
             }
-            Spacer(Modifier.height(8.dp))
-            ExposedDropdownMenuBox(expanded = groupExpanded, onExpandedChange = { groupExpanded = !groupExpanded }) {
-                OutlinedTextField(
-                    readOnly = true,
-                    value = group.display,
-                    onValueChange = {},
-                    label = { Text(stringResource(id = R.string.muscle_group)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = groupExpanded) },
-                    modifier = Modifier.menuAnchor().fillMaxWidth()
-                )
-                ExposedDropdownMenu(expanded = groupExpanded, onDismissRequest = { groupExpanded = false }) {
-                    MuscleGroup.values().forEach {
-                        DropdownMenuItem(text = { Text(it.display) }, onClick = {
-                            group = it
-                            muscle = musclesByGroup[it]?.first() ?: ""
-                            groupExpanded = false
-                        })
+            if (category != ExerciseCategory.Cardio) {
+                Spacer(Modifier.height(8.dp))
+                ExposedDropdownMenuBox(expanded = groupExpanded, onExpandedChange = { groupExpanded = !groupExpanded }) {
+                    OutlinedTextField(
+                        readOnly = true,
+                        value = group.display,
+                        onValueChange = {},
+                        label = { Text(stringResource(id = R.string.muscle_group)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = groupExpanded) },
+                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(expanded = groupExpanded, onDismissRequest = { groupExpanded = false }) {
+                        MuscleGroup.values().forEach {
+                            DropdownMenuItem(text = { Text(it.display) }, onClick = {
+                                group = it
+                                muscle = musclesByGroup[it]?.first() ?: ""
+                                groupExpanded = false
+                            })
+                        }
                     }
                 }
-            }
-            Spacer(Modifier.height(8.dp))
-            val muscles = musclesByGroup[group] ?: emptyList()
-            ExposedDropdownMenuBox(expanded = muscleExpanded, onExpandedChange = { muscleExpanded = !muscleExpanded }) {
-                OutlinedTextField(
-                    readOnly = true,
-                    value = muscle,
-                    onValueChange = {},
-                    label = { Text(stringResource(id = R.string.muscle)) },
-                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = muscleExpanded) },
-                    modifier = Modifier.menuAnchor().fillMaxWidth()
-                )
-                ExposedDropdownMenu(expanded = muscleExpanded, onDismissRequest = { muscleExpanded = false }) {
-                    muscles.forEach { option ->
-                        DropdownMenuItem(text = { Text(option) }, onClick = {
-                            muscle = option
-                            muscleExpanded = false
-                        })
+                Spacer(Modifier.height(8.dp))
+                val muscles = musclesByGroup[group] ?: emptyList()
+                ExposedDropdownMenuBox(expanded = muscleExpanded, onExpandedChange = { muscleExpanded = !muscleExpanded }) {
+                    OutlinedTextField(
+                        readOnly = true,
+                        value = muscle,
+                        onValueChange = {},
+                        label = { Text(stringResource(id = R.string.muscle)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = muscleExpanded) },
+                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(expanded = muscleExpanded, onDismissRequest = { muscleExpanded = false }) {
+                        muscles.forEach { option ->
+                            DropdownMenuItem(text = { Text(option) }, onClick = {
+                                muscle = option
+                                muscleExpanded = false
+                            })
+                        }
                     }
                 }
             }
@@ -148,7 +150,7 @@ fun AddExerciseScreen(
                         viewModel.insert(exercise)
                         onDone()
                     },
-                    enabled = name.isNotBlank() && muscle.isNotBlank(),
+                    enabled = name.isNotBlank() && (category == ExerciseCategory.Cardio || muscle.isNotBlank()),
                     modifier = Modifier.weight(1f)
                 ) { Text(stringResource(id = R.string.save)) }
                 OutlinedButton(onClick = onCancel, modifier = Modifier.weight(1f)) { Text(stringResource(id = R.string.cancel)) }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/ExerciseListScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/ExerciseListScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.viewmodel.ExerciseViewModel
-import com.example.mygymapp.ui.widgets.StarRating
+import com.example.mygymapp.ui.widgets.DifficultyRating
 import androidx.compose.material.ExperimentalMaterialApi
 
 
@@ -60,8 +60,10 @@ fun ExerciseListScreen(
                     ) { exercise ->
                         val dismissState = rememberDismissState()
                         if (dismissState.isDismissed(DismissDirection.EndToStart)) {
-                            onEditExercise(exercise.id)
-                            LaunchedEffect(Unit) { dismissState.reset() }
+                            LaunchedEffect(exercise.id) {
+                                dismissState.reset()
+                                onEditExercise(exercise.id)
+                            }
                         }
                         if (dismissState.isDismissed(DismissDirection.StartToEnd)) {
                             viewModel.delete(exercise.id)
@@ -141,7 +143,7 @@ fun ExerciseListItem(ex: Exercise) {
                 Text(ex.name, style = MaterialTheme.typography.titleMedium)
                 Text("${ex.muscleGroup} • ${ex.category}", style = MaterialTheme.typography.bodySmall)
             }
-            StarRating(rating = ex.likeability)
+            DifficultyRating(rating = ex.likeability)
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/WorkoutScreen.kt
@@ -43,6 +43,7 @@ fun WorkoutScreen(viewModel: WorkoutViewModel = viewModel()) {
     val weeklyPlans by viewModel.weeklyPlans.observeAsState(emptyList())
     val dailyPlans by viewModel.dailyPlans.observeAsState(emptyList())
     val plan by viewModel.todayPlan.observeAsState()
+    val _exercises by viewModel.exercises.observeAsState(emptyList())
     val nav = rememberNavController()
     var newWeeklyPlan by remember { mutableStateOf<Plan?>(null) }
     var restDay by remember { mutableIntStateOf(-1) }
@@ -302,7 +303,8 @@ private fun WorkoutDayScreen(
 
 @Composable
 private fun FinishDayScreen(progress: WeekProgress?, onContinue: () -> Unit) {
-    val text = if (progress == null) stringResource(R.string.week_complete) else stringResource(R.string.day_finished, dayName(progress.day))
+    val finishedDay = progress?.day?.minus(1) ?: 0
+    val text = if (progress == null) stringResource(R.string.week_complete) else stringResource(R.string.day_finished, dayName(finishedDay))
     val button = if (progress == null) stringResource(R.string.back_to_start) else stringResource(R.string.next_day)
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {


### PR DESCRIPTION
## Summary
- hide muscle fields when cardio is selected
- show leaf difficulty icons in exercise list
- reset swipe state before editing exercises
- observe exercises in workout screen
- fix wrong day name after finishing a workout day

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc0832d28832a9a9021eb0e64170f