### PR TITLE
Revamp themes with atmospheric designs

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/screens/DailyPlansTab.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/DailyPlansTab.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavController
 import com.example.mygymapp.ui.theme.EditGray
-import com.example.mygymapp.ui.theme.NatureGreen
+import com.example.mygymapp.ui.theme.PineGreen
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -81,7 +81,7 @@ fun DailyPlansTab(navController: NavController) {
                                 .padding(horizontal = 20.dp),
                             contentAlignment = align
                         ) {
-                            Icon(icon, contentDescription = null, tint = NatureGreen)
+                            Icon(icon, contentDescription = null, tint = PineGreen)
                         }
                     },
                     dismissContent = {

--- a/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
@@ -27,7 +27,7 @@ import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.viewmodel.ExerciseViewModel
 import com.example.mygymapp.ui.widgets.StarRating
 import com.example.mygymapp.ui.theme.EditGray
-import com.example.mygymapp.ui.theme.NatureGreen
+import com.example.mygymapp.ui.theme.PineGreen
 
 @Composable
 @OptIn(ExperimentalMaterialApi::class)
@@ -105,7 +105,7 @@ private fun ExerciseListItem(ex: Exercise, onEdit: (Long) -> Unit, viewModel: Ex
                     .padding(horizontal = 20.dp),
                 contentAlignment = alignment
             ) {
-                Icon(icon, contentDescription = null, tint = NatureGreen)
+                Icon(icon, contentDescription = null, tint = PineGreen)
             }
         },
         dismissContent = {

--- a/app/src/main/java/com/example/mygymapp/ui/screens/WeeklyPlansTab.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/WeeklyPlansTab.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavController
 import com.example.mygymapp.ui.theme.EditGray
-import com.example.mygymapp.ui.theme.NatureGreen
+import com.example.mygymapp.ui.theme.PineGreen
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -85,7 +85,7 @@ fun WeeklyPlansTab(navController: NavController) {
                                 .padding(horizontal = 20.dp),
                             contentAlignment = align
                         ) {
-                            Icon(icon, contentDescription = null, tint = NatureGreen)
+                            Icon(icon, contentDescription = null, tint = PineGreen)
                         }
                     },
                     dismissContent = {

--- a/app/src/main/java/com/example/mygymapp/ui/theme/BeachTheme.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/BeachTheme.kt
@@ -1,42 +1,39 @@
 package com.example.mygymapp.ui.theme
 
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.mygymapp.navigation.AppNavHost
 import com.example.mygymapp.navigation.NavTabs
-import androidx.compose.animation.core.*
 
-private val BeachColorScheme = lightColorScheme(
-    primary = Coral,
-    onPrimary = DeepBlack,
-    secondary = Turquoise,
-    onSecondary = DeepBlack,
-    background = Sand,
-    onBackground = DeepBlack,
-    surface = Sand,
-    onSurface = DeepBlack
-)
-
-private val BeachShapes = Shapes(
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(0.dp)
+private val BeachColors = lightColorScheme(
+    primary = SunsetCoral,
+    onPrimary = NightBlack,
+    secondary = WaveBlue,
+    onSecondary = NightBlack,
+    background = BeachSand,
+    onBackground = NightBlack,
+    surface = BeachSand,
+    onSurface = NightBlack
 )
 
 @Composable
@@ -45,74 +42,66 @@ fun BeachTheme(animationsEnabled: Boolean = true) {
     val current by navController.currentBackStackEntryAsState()
     val index = NavTabs.indexOfFirst { it.route == current?.destination?.route }.let { if (it >= 0) it else 0 }
 
-    Crossfade(targetState = BeachColorScheme) { colors ->
-        MaterialTheme(colorScheme = colors, shapes = BeachShapes) {
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(colors = listOf(SkyBlue, Sand))
-                    )
-            ) {
-                WaveBackground(Modifier.matchParentSize(), animationsEnabled)
-                Scaffold(
-                    containerColor = Color.Transparent,
-                    bottomBar = {
-                        NavigationBar(containerColor = Sand) {
-                            NavTabs.forEachIndexed { idx, tab ->
-                                NavigationBarItem(
-                                    selected = idx == index,
-                                    onClick = {
-                                        navController.navigate(tab.route) {
-                                            popUpTo(navController.graph.startDestinationId) { saveState = true }
-                                            launchSingleTop = true
-                                            restoreState = true
-                                        }
-                                    },
-                                    icon = { Icon(tab.icon, contentDescription = tab.label) },
-                                    label = { Text(tab.label) }
-                                )
-                            }
+    MaterialTheme(colorScheme = BeachColors) {
+        Box(Modifier.fillMaxSize().background(BeachSand)) {
+            BeachScene(Modifier.fillMaxSize(), animationsEnabled)
+            androidx.compose.material3.Scaffold(
+                containerColor = Color.Transparent,
+                bottomBar = {
+                    NavigationBar(containerColor = BeachColors.surface) {
+                        NavTabs.forEachIndexed { idx, tab ->
+                            NavigationBarItem(
+                                selected = idx == index,
+                                onClick = {
+                                    navController.navigate(tab.route) {
+                                        popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
+                                },
+                                icon = { androidx.compose.material3.Icon(tab.icon, tab.label) },
+                                label = { androidx.compose.material3.Text(tab.label) }
+                            )
                         }
                     }
-                ) { padding ->
-                    AppNavHost(navController, Modifier.padding(padding))
                 }
+            ) { padding ->
+                AppNavHost(navController, Modifier.padding(padding))
             }
         }
     }
 }
 
 @Composable
-private fun WaveBackground(modifier: Modifier = Modifier, animationsEnabled: Boolean) {
-    val transition = rememberInfiniteTransition(label = "waves")
-    val offset by transition.animateFloat(
+private fun BeachScene(modifier: Modifier = Modifier, animationsEnabled: Boolean) {
+    val transition = rememberInfiniteTransition(label = "wave")
+    val anim by transition.animateFloat(
         initialValue = 0f,
         targetValue = if (animationsEnabled) 1f else 0f,
-        animationSpec = infiniteRepeatable(tween(8000, easing = LinearEasing))
+        animationSpec = infiniteRepeatable(tween(10000, easing = LinearEasing))
     )
     Canvas(modifier) {
         val w = size.width
         val h = size.height
-        val y1 = h * 0.3f
-        val y2 = h * 0.32f
-        val dx = w * offset
-        val path1 = Path().apply {
-            moveTo(-w + dx, y1)
-            cubicTo(-w * 0.5f + dx, y1 + 20f, w * 0.5f + dx, y1 - 20f, w + dx, y1)
-            lineTo(w + dx, 0f)
-            lineTo(-w + dx, 0f)
+        val horizon = h * 0.35f
+        drawRect(BeachSand, Offset(0f, horizon), androidx.compose.ui.geometry.Size(w, h - horizon))
+        val dy = h * 0.05f
+        val dx = w * anim
+        val wave1 = Path().apply {
+            moveTo(-w + dx, horizon)
+            cubicTo(-w * 0.5f + dx, horizon + dy, w * 0.5f + dx, horizon - dy, w + dx, horizon)
+            lineTo(w + dx, horizon - dy * 2)
+            lineTo(-w + dx, horizon - dy * 2)
             close()
         }
-        val path2 = Path().apply {
-            moveTo(-w + dx * 1.2f, y2)
-            cubicTo(-w * 0.5f + dx * 1.2f, y2 + 20f, w * 0.5f + dx * 1.2f, y2 - 20f, w + dx * 1.2f, y2)
-            lineTo(w + dx * 1.2f, 0f)
-            lineTo(-w + dx * 1.2f, 0f)
+        val wave2 = Path().apply {
+            moveTo(-w + dx * 1.3f, horizon - dy * 1.5f)
+            cubicTo(-w * 0.4f + dx * 1.3f, horizon - dy * 0.5f, w * 0.6f + dx * 1.3f, horizon - dy * 2.5f, w + dx * 1.3f, horizon - dy * 1.5f)
+            lineTo(w + dx * 1.3f, horizon - dy * 3)
+            lineTo(-w + dx * 1.3f, horizon - dy * 3)
             close()
         }
-        drawRect(Sand, topLeft = Offset(0f, y2), size = androidx.compose.ui.geometry.Size(w, h - y2))
-        drawPath(path1, SkyBlue)
-        drawPath(path2, Turquoise.copy(alpha = 0.5f))
+        drawPath(wave1, WaveBlue)
+        drawPath(wave2, SeaFoam.copy(alpha = 0.7f))
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/Color.kt
@@ -2,24 +2,26 @@ package com.example.mygymapp.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val DarkGreen = Color(0xFF121515) // sidebar and surfaces
-val NatureGreen = Color(0xFF1F9D55) // primary accent
-val DeepBlack = Color(0xFF0A0C0B) // background
-val OnDark = Color(0xFFE2E8E6) // text on dark surfaces
-val AccentGreen = Color(0xFF1F9D55) // accent (same as primary)
-val KaizenBeige = Color(0xFF2E3B38) // card background
-val ErrorRed = Color(0xFFD00036)
-val InactiveGray = Color(0xFF606060) // inactive icons
-val EditGray = Color(0xFF2E2E2E) // swipe edit background
+// General colors
+val NightBlack = Color(0xFF0B0E0B)
+val FogGray = Color(0xFF5C6660)
+val LightText = Color(0xFFE2E8E6)
 
-// Mountains theme colors
-val MountainBlue = Color(0xFF90CAF9)
-val GlacierAccent = Color(0xFFB3E5FC)
-val SnowWhite = Color(0xFFFFFFFF)
-val MistGray = Color(0xFFE0E0E0)
+// Dark forest palette
+val ForestShadow = Color(0xFF112016)
+val PineGreen = Color(0xFF1D3B29)
+val FireflyYellow = Color(0xFFFFF9B0)
 
-// Beach theme colors
-val Sand = Color(0xFFFFE0B2)
-val SkyBlue = Color(0xFF81D4FA)
-val Coral = Color(0xFFFF8A65)
-val Turquoise = Color(0xFF80DEEA)
+// Mountain palette
+val MountainDeepBlue = Color(0xFF0D1B2A)
+val GlacierBlue = Color(0xFF6EA8DA)
+val DuskViolet = Color(0xFFA7A8D9)
+val SnowFlake = Color(0xFFFFFFFF)
+val FogLight = Color(0x66FFFFFF)
+
+// Beach palette
+val BeachSand = Color(0xFFF7E3C2)
+val WaveBlue = Color(0xFF78C6F6)
+val SeaFoam = Color(0xFF90E0EF)
+val SunsetCoral = Color(0xFFFF9172)
+val SunYellow = Color(0xFFFFD684)

--- a/app/src/main/java/com/example/mygymapp/ui/theme/DarkForestTheme.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/DarkForestTheme.kt
@@ -1,161 +1,157 @@
 package com.example.mygymapp.ui.theme
 
-import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.*
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.mygymapp.navigation.AppNavHost
 import com.example.mygymapp.navigation.NavTabs
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sin
 import kotlin.random.Random
 
-private val DarkForestColors = darkColorScheme(
-    primary = NatureGreen,
-    onPrimary = OnDark,
-    secondary = DarkGreen,
-    onSecondary = OnDark,
-    background = DeepBlack,
-    onBackground = OnDark,
-    surface = DarkGreen,
-    onSurface = OnDark
-)
-
-private val DarkShapes = androidx.compose.material3.Shapes(
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(12.dp),
-    large = RoundedCornerShape(0.dp)
+private val ForestColors = darkColorScheme(
+    primary = PineGreen,
+    onPrimary = LightText,
+    secondary = ForestShadow,
+    onSecondary = LightText,
+    background = NightBlack,
+    onBackground = LightText,
+    surface = ForestShadow,
+    onSurface = LightText
 )
 
 @Composable
 fun DarkForestTheme(animationsEnabled: Boolean = true) {
     val navController = rememberNavController()
-    val current = navController.currentBackStackEntryAsState().value?.destination?.route
-    val items = remember { NavTabs.map { DarkNavItem(it.route, it.label, it.icon) } }
+    val current by navController.currentBackStackEntryAsState()
+    val currentRoute = current?.destination?.route ?: NavTabs.first().route
 
-    Crossfade(targetState = true) { _ ->
-        MaterialTheme(colorScheme = DarkForestColors, shapes = DarkShapes) {
-            Box(Modifier.fillMaxSize()) {
-                ForestBackground(Modifier.matchParentSize())
-                RainEffect(Modifier.matchParentSize(), animationsEnabled = animationsEnabled)
-                androidx.compose.foundation.layout.Row {
-                    DarkForestSidebar(
-                        items = items,
-                        current = current ?: items.first().route,
-                        onSelect = { route ->
-                            navController.navigate(route) {
-                                popUpTo(navController.graph.startDestinationId) { saveState = true }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        }
-                    )
-                    Box(Modifier.weight(1f)) {
-                        AppNavHost(navController = navController)
+    MaterialTheme(colorScheme = ForestColors) {
+        Box(Modifier.fillMaxSize().background(NightBlack)) {
+            ForestScene(Modifier.fillMaxSize())
+            Rain(modifier = Modifier.fillMaxSize(), animationsEnabled)
+            Fireflies(modifier = Modifier.fillMaxSize(), animationsEnabled)
+            Row {
+                NavigationRail(containerColor = ForestColors.surface) {
+                    NavTabs.forEach { tab ->
+                        NavigationRailItem(
+                            selected = currentRoute == tab.route,
+                            onClick = {
+                                navController.navigate(tab.route) {
+                                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                            icon = { androidx.compose.material3.Icon(tab.icon, tab.label) },
+                            colors = NavigationRailItemDefaults.colors(
+                                selectedIconColor = PineGreen,
+                                unselectedIconColor = FogGray,
+                                indicatorColor = Color.Transparent
+                            )
+                        )
                     }
+                }
+                Box(Modifier.weight(1f)) {
+                    AppNavHost(navController)
                 }
             }
         }
     }
 }
 
+private data class Tree(val x: Float, val size: Float)
+
 @Composable
-fun DarkForestSidebar(
-    items: List<DarkNavItem>,
-    current: String,
-    onSelect: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    NavigationRail(modifier.background(DarkForestColors.surface)) {
-        items.forEach { item ->
-            NavigationRailItem(
-                selected = current == item.route,
-                onClick = { onSelect(item.route) },
-                icon = { androidx.compose.material3.Icon(item.icon, contentDescription = item.label) },
-                colors = NavigationRailItemDefaults.colors(
-                    selectedIconColor = NatureGreen,
-                    unselectedIconColor = InactiveGray,
-                    indicatorColor = Color.Transparent
-                )
-            )
+private fun ForestScene(modifier: Modifier = Modifier) {
+    val layers = remember {
+        List(3) { layer ->
+            val r = Random(layer)
+            List(8) { Tree(r.nextFloat(), r.nextFloat()) }
+        }
+    }
+    Canvas(modifier) {
+        val width = size.width
+        val height = size.height
+        val colors = listOf(ForestShadow, ForestShadow.copy(alpha = 0.8f), ForestShadow.copy(alpha = 0.6f))
+        layers.forEachIndexed { index, trees ->
+            val base = height * (0.65f + index * 0.1f)
+            trees.forEach { tree ->
+                val h = height * (0.25f + tree.size * 0.15f)
+                val w = h * 0.4f
+                val center = width * tree.x
+                val path = Path().apply {
+                    moveTo(center, base - h)
+                    quadraticBezierTo(center - w * 0.5f, base - h * 0.6f, center, base - h * 0.3f)
+                    quadraticBezierTo(center + w * 0.5f, base - h * 0.6f, center, base - h)
+                }
+                drawPath(path, colors[index])
+                drawRect(colors[index], Offset(center - w * 0.1f, base - h * 0.3f), androidx.compose.ui.geometry.Size(w * 0.2f, h * 0.3f))
+            }
         }
     }
 }
-
-data class DarkNavItem(val route: String, val label: String, val icon: ImageVector)
 
 private data class Drop(val x: Float, val speed: Float, val length: Float)
 
 @Composable
-private fun ForestBackground(modifier: Modifier = Modifier) {
-    val layers = remember {
-        List(3) { layer ->
-            val rand = Random(layer)
-            List(10) { Pair(rand.nextFloat(), rand.nextFloat() * 0.3f + 0.2f) }
-        }
-    }
-    Canvas(modifier) {
-        val h = size.height
-        val w = size.width
-        val colors = listOf(DarkGreen, DarkGreen.copy(alpha = 0.7f), DarkGreen.copy(alpha = 0.5f))
-        layers.forEachIndexed { index, points ->
-            val baseY = h * (0.7f + index * 0.1f)
-            val path = Path().apply {
-                moveTo(0f, h)
-                lineTo(0f, baseY)
-                points.forEach { (x, peak) ->
-                    lineTo(w * x, baseY)
-                    lineTo(w * x + w * 0.05f, baseY - h * peak)
-                    lineTo(w * x + w * 0.1f, baseY)
-                }
-                lineTo(w, baseY)
-                lineTo(w, h)
-                close()
-            }
-            drawPath(path, colors[index])
-        }
-    }
-}
-
-@Composable
-private fun RainEffect(modifier: Modifier = Modifier, count: Int = 40, dropColor: Color = Color.White.copy(alpha = 0.15f), stroke: Dp = 2.dp, animationsEnabled: Boolean) {
+private fun Rain(modifier: Modifier = Modifier, animationsEnabled: Boolean, count: Int = 40) {
     val drops = remember { List(count) { Drop(Random.nextFloat(), Random.nextFloat() * 4 + 2, Random.nextFloat() * 0.1f + 0.05f) } }
     val transition = rememberInfiniteTransition(label = "rain")
     val anim by transition.animateFloat(
         initialValue = 0f,
         targetValue = if (animationsEnabled) 1f else 0f,
-        animationSpec = infiniteRepeatable(animation = tween(durationMillis = 1500, easing = LinearEasing))
+        animationSpec = infiniteRepeatable(tween(1600, easing = LinearEasing))
     )
-    Canvas(modifier = modifier) {
+    Canvas(modifier) {
         drops.forEach { drop ->
             val y = (anim * drop.speed + drop.x) % 1f
             val startY = size.height * y
             val endY = startY + size.height * drop.length
-            drawLine(
-                dropColor,
-                start = Offset(size.width * drop.x, startY),
-                end = Offset(size.width * drop.x, endY),
-                strokeWidth = stroke.toPx()
-            )
+            drawLine(Color.White.copy(alpha = 0.1f), Offset(size.width * drop.x, startY), Offset(size.width * drop.x, endY), strokeWidth = 2f)
         }
     }
 }
 
+private data class Firefly(val x: Float, val y: Float, val phase: Float)
+
+@Composable
+private fun Fireflies(modifier: Modifier = Modifier, animationsEnabled: Boolean, count: Int = 20) {
+    val flies = remember { List(count) { Firefly(Random.nextFloat(), Random.nextFloat() * 0.6f, Random.nextFloat()) } }
+    val transition = rememberInfiniteTransition(label = "flies")
+    val time by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = if (animationsEnabled) 1f else 0f,
+        animationSpec = infiniteRepeatable(tween(4000, easing = LinearEasing), RepeatMode.Restart)
+    )
+    Canvas(modifier) {
+        flies.forEach { f ->
+            val alpha = abs(sin((time + f.phase) * 2f * PI)).toFloat()
+            drawCircle(FireflyYellow.copy(alpha = alpha), radius = 3f, center = Offset(size.width * f.x, size.height * f.y))
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/theme/MountainTheme.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/MountainTheme.kt
@@ -1,52 +1,41 @@
 package com.example.mygymapp.ui.theme
 
-import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.Image
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.compose.animation.core.*
-import kotlin.random.Random
 import com.example.mygymapp.navigation.AppNavHost
 import com.example.mygymapp.navigation.NavTabs
-import com.example.mygymapp.R
+import kotlin.random.Random
 
-private val MountainColorScheme = lightColorScheme(
-    primary = MountainBlue,
-    onPrimary = SnowWhite,
-    secondary = GlacierAccent,
-    onSecondary = SnowWhite,
-    background = SnowWhite,
-    onBackground = MountainBlue,
-    surface = SnowWhite,
-    onSurface = MountainBlue
-)
-
-private val MountainShapes = Shapes(
-    small = RoundedCornerShape(6.dp),
-    medium = RoundedCornerShape(12.dp),
-    large = RoundedCornerShape(0.dp)
+private val MountainColors = lightColorScheme(
+    primary = GlacierBlue,
+    onPrimary = SnowFlake,
+    secondary = DuskViolet,
+    onSecondary = SnowFlake,
+    background = SnowFlake,
+    onBackground = MountainDeepBlue,
+    surface = SnowFlake,
+    onSurface = MountainDeepBlue
 )
 
 @Composable
@@ -55,83 +44,49 @@ fun MountainTheme(animationsEnabled: Boolean = true) {
     val current by navController.currentBackStackEntryAsState()
     val index = NavTabs.indexOfFirst { it.route == current?.destination?.route }.let { if (it >= 0) it else 0 }
 
-    Crossfade(targetState = MountainColorScheme) { colors ->
-        MaterialTheme(colorScheme = colors, shapes = MountainShapes) {
-            Box(Modifier.fillMaxSize()) {
-                MountainBackground(Modifier.matchParentSize())
-                SnowEffect(Modifier.matchParentSize(), animationsEnabled = animationsEnabled)
-                Scaffold(
-                    containerColor = Color.Transparent,
-                    topBar = {
-                        Column(Modifier.statusBarsPadding()) {
-                            ParallaxHeader()
-                            TabRow(selectedTabIndex = index, containerColor = Color.Transparent) {
-                                NavTabs.forEachIndexed { idx, tab ->
-                                    Tab(
-                                        selected = idx == index,
-                                        onClick = {
-                                            navController.navigate(tab.route) {
-                                                popUpTo(navController.graph.startDestinationId) { saveState = true }
-                                                launchSingleTop = true
-                                                restoreState = true
-                                            }
-                                        },
-                                        icon = {
-                                            Icon(
-                                                tab.icon,
-                                                contentDescription = tab.label,
-                                                modifier = Modifier.graphicsLayer { translationY = if (idx % 2 == 0) 0f else 6f }
-                                            )
-                                        }
-                                    )
+    MaterialTheme(colorScheme = MountainColors) {
+        Box(Modifier.fillMaxSize().background(MountainDeepBlue)) {
+            MountainScene(Modifier.fillMaxSize())
+            FogOverlay(Modifier.fillMaxSize(), animationsEnabled)
+            androidx.compose.material3.Scaffold(
+                containerColor = Color.Transparent,
+                bottomBar = {
+                    TabRow(selectedTabIndex = index, containerColor = MountainColors.surface) {
+                        NavTabs.forEachIndexed { idx, tab ->
+                            Tab(selected = idx == index, onClick = {
+                                navController.navigate(tab.route) {
+                                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                            }
+                            }, icon = { androidx.compose.material3.Icon(tab.icon, tab.label) })
                         }
                     }
-                ) { padding ->
-                    AppNavHost(navController, Modifier.padding(padding))
                 }
+            ) { padding ->
+                AppNavHost(navController, Modifier.padding(padding))
             }
         }
     }
 }
 
-@Composable
-fun ParallaxHeader(modifier: Modifier = Modifier) {
-    val height = 200.dp
-    Box(
-        modifier
-            .fillMaxWidth()
-            .height(height)
-    ) {
-        Image(
-            painterResource(R.drawable.ic_mountain),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize()
-        )
-        // simple transparent overlay hinting at snow/wind
-        Box(Modifier.matchParentSize().background(SnowWhite.copy(alpha = 0.1f)))
-    }
-}
+private fun curvedRange(random: Random): List<Pair<Float, Float>> =
+    List(6) { it / 5f to (0.4f + random.nextFloat() * 0.2f) }
 
 @Composable
-private fun MountainBackground(modifier: Modifier = Modifier) {
+private fun MountainScene(modifier: Modifier = Modifier) {
     val layers = remember {
-        listOf(
-            listOf(0f to 0.6f, 0.2f to 0.4f, 0.4f to 0.55f, 0.6f to 0.35f, 0.8f to 0.5f, 1f to 0.4f),
-            listOf(0f to 0.8f, 0.3f to 0.6f, 0.6f to 0.75f, 0.8f to 0.5f, 1f to 0.7f)
-        )
+        listOf(curvedRange(Random(1)), curvedRange(Random(2)))
     }
     Canvas(modifier) {
-        val h = size.height
         val w = size.width
-        val colors = listOf(MountainBlue.copy(alpha = 0.6f), MountainBlue.copy(alpha = 0.4f))
-        layers.forEachIndexed { idx, pts ->
+        val h = size.height
+        val colors = listOf(MountainDeepBlue.copy(alpha = 0.6f), MountainDeepBlue.copy(alpha = 0.4f))
+        layers.forEachIndexed { idx, points ->
             val path = Path().apply {
                 moveTo(0f, h)
-                lineTo(pts.first().first * w, pts.first().second * h)
-                pts.drop(1).forEach { (x, y) -> lineTo(x * w, y * h) }
+                lineTo(points.first().first * w, points.first().second * h)
+                points.drop(1).forEach { (x, y) -> quadraticBezierTo(x * w, y * h - h * 0.05f, x * w, y * h) }
                 lineTo(w, h)
                 close()
             }
@@ -140,21 +95,26 @@ private fun MountainBackground(modifier: Modifier = Modifier) {
     }
 }
 
-private data class Flake(val x: Float, val speed: Float, val size: Float)
-
 @Composable
-private fun SnowEffect(modifier: Modifier = Modifier, count: Int = 30, animationsEnabled: Boolean) {
-    val flakes = remember { List(count) { Flake(Random.nextFloat(), Random.nextFloat() * 0.5f + 0.5f, Random.nextFloat() * 3f + 2f) } }
-    val transition = rememberInfiniteTransition(label = "snow")
+private fun FogOverlay(modifier: Modifier = Modifier, animationsEnabled: Boolean) {
+    val transition = rememberInfiniteTransition(label = "fog")
     val anim by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = if (animationsEnabled) 1f else 0f,
-        animationSpec = infiniteRepeatable(tween(6000, easing = LinearEasing))
+        initialValue = -1f,
+        targetValue = if (animationsEnabled) 1f else -1f,
+        animationSpec = infiniteRepeatable(tween(15000, easing = LinearEasing))
     )
     Canvas(modifier) {
-        flakes.forEach { flake ->
-            val y = (anim * flake.speed + flake.x) % 1f
-            drawCircle(Color.White.copy(alpha = 0.8f), flake.size, Offset(size.width * flake.x, size.height * y))
-        }
+        val w = size.width
+        val h = size.height
+        val y = h * 0.5f
+        drawRect(
+            brush = androidx.compose.ui.graphics.Brush.horizontalGradient(
+                listOf(Color.Transparent, FogLight, Color.Transparent),
+                startX = -w + w * anim,
+                endX = w + w * anim
+            ),
+            topLeft = Offset(-w + w * anim, y),
+            size = androidx.compose.ui.geometry.Size(w * 2, h * 0.3f)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- overhaul color palette for new visuals
- implement DarkForestTheme with layered trees, rain and fireflies
- rewrite MountainTheme with curved mountain layers and drifting fog
- recreate BeachTheme using animated waves and sunset colors
- update screen files to use new PineGreen accent color

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701722c524832a92302e9f3e0dba46