### PR TITLE
Add exercise filtering and favorites

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
@@ -14,7 +14,7 @@ import com.example.mygymapp.data.PlanDay
         Exercise::class,
         PlanDay::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 @TypeConverters(PlanConverters::class)

--- a/app/src/main/java/com/example/mygymapp/data/Exercise.kt
+++ b/app/src/main/java/com/example/mygymapp/data/Exercise.kt
@@ -14,5 +14,6 @@ data class Exercise(
     val likeability: Int,
     val muscleGroup: MuscleGroup,   // <- model.MuscleGroup
     val muscle: String,
-    val imageUri: String? = null
+    val imageUri: String? = null,
+    val isFavorite: Boolean = false
 )

--- a/app/src/main/java/com/example/mygymapp/ui/components/SearchFilterBar.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SearchFilterBar.kt
@@ -17,7 +17,8 @@ fun SearchFilterBar(
     query: String,
     onQueryChange: (String) -> Unit,
     favoritesOnly: Boolean,
-    onFavoritesToggle: () -> Unit
+    onFavoritesToggle: () -> Unit,
+    placeholderRes: Int = R.string.search_plans
 ) {
     Row(
         modifier = Modifier
@@ -29,7 +30,7 @@ fun SearchFilterBar(
         TextField(
             value = query,
             onValueChange = onQueryChange,
-            placeholder = { Text(stringResource(id = R.string.search_plans)) },
+            placeholder = { Text(stringResource(id = placeholderRes)) },
             modifier = Modifier.weight(1f)
         )
         Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
@@ -8,14 +8,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.DismissDirection
 import androidx.compose.material.DismissValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +30,21 @@ import com.example.mygymapp.viewmodel.ExerciseViewModel
 import com.example.mygymapp.ui.widgets.StarRating
 import com.example.mygymapp.ui.theme.FogGray
 import com.example.mygymapp.ui.theme.PineGreen
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.model.MuscleGroup
+import com.example.mygymapp.ui.components.SearchFilterBar
+import coil.compose.AsyncImage
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.ui.res.stringResource
+import com.example.mygymapp.R
+
+private enum class SortOption(val labelRes: Int, val comparator: Comparator<Exercise>) {
+    NAME(R.string.sort_name, compareBy { it.name.lowercase() }),
+    DIFFICULTY(R.string.sort_difficulty, compareBy { it.likeability }),
+    MUSCLE(R.string.sort_muscle_group, compareBy { it.muscleGroup.display })
+}
 
 @Composable
 @OptIn(ExperimentalMaterialApi::class)
@@ -37,6 +54,22 @@ fun ExercisesScreen(
     onEditExercise: (Long) -> Unit = {}
 ) {
     val exercises by viewModel.allExercises.observeAsState(emptyList())
+
+    var query by rememberSaveable { mutableStateOf("") }
+    var showFavorites by rememberSaveable { mutableStateOf(false) }
+    var selectedCategory by rememberSaveable { mutableStateOf<ExerciseCategory?>(null) }
+    var selectedGroup by rememberSaveable { mutableStateOf<MuscleGroup?>(null) }
+    var sortExpanded by rememberSaveable { mutableStateOf(false) }
+    var sortOption by rememberSaveable { mutableStateOf(SortOption.NAME) }
+
+    val filtered = exercises
+        .asSequence()
+        .filter { if (showFavorites) it.isFavorite else true }
+        .filter { selectedCategory?.let { cat -> it.category == cat } ?: true }
+        .filter { selectedGroup?.let { grp -> it.muscleGroup == grp } ?: true }
+        .filter { it.name.contains(query, true) || it.description.contains(query, true) }
+        .sortedWith(sortOption.comparator)
+        .toList()
     Scaffold(
         containerColor = Color.Transparent,
         floatingActionButton = {
@@ -55,17 +88,83 @@ fun ExercisesScreen(
                 Text("No exercises yet!", style = MaterialTheme.typography.titleMedium)
             }
         } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-            ) {
-                items(exercises, key = { it.id }) { ex ->
-                    ExerciseListItem(
-                        ex = ex,
-                        onEdit = { onEditExercise(it) },
-                        viewModel = viewModel
+            Column(Modifier.padding(paddingValues)) {
+                SearchFilterBar(
+                    query = query,
+                    onQueryChange = { query = it },
+                    favoritesOnly = showFavorites,
+                    onFavoritesToggle = { showFavorites = !showFavorites },
+                    placeholderRes = R.string.search_exercises
+                )
+
+                FlowRow(modifier = Modifier.padding(horizontal = 8.dp)) {
+                    FilterChip(
+                        selected = selectedCategory == null,
+                        onClick = { selectedCategory = null },
+                        label = { Text(stringResource(id = R.string.all)) }
                     )
+                    ExerciseCategory.values().forEach { cat ->
+                        Spacer(Modifier.width(8.dp))
+                        FilterChip(
+                            selected = selectedCategory == cat,
+                            onClick = { selectedCategory = cat },
+                            label = { Text(cat.display) }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(4.dp))
+
+                FlowRow(modifier = Modifier.padding(horizontal = 8.dp)) {
+                    FilterChip(
+                        selected = selectedGroup == null,
+                        onClick = { selectedGroup = null },
+                        label = { Text(stringResource(id = R.string.all)) }
+                    )
+                    MuscleGroup.values().forEach { grp ->
+                        Spacer(Modifier.width(8.dp))
+                        FilterChip(
+                            selected = selectedGroup == grp,
+                            onClick = { selectedGroup = grp },
+                            label = { Text(grp.display) }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                ExposedDropdownMenuBox(expanded = sortExpanded, onExpandedChange = { sortExpanded = !sortExpanded }) {
+                    OutlinedTextField(
+                        readOnly = true,
+                        value = stringResource(id = sortOption.labelRes),
+                        onValueChange = {},
+                        label = { Text(stringResource(id = R.string.sort_by)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = sortExpanded) },
+                        modifier = Modifier.menuAnchor().padding(horizontal = 8.dp).fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(expanded = sortExpanded, onDismissRequest = { sortExpanded = false }) {
+                        SortOption.values().forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(id = option.labelRes)) },
+                                onClick = {
+                                    sortOption = option
+                                    sortExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(filtered, key = { it.id }) { ex ->
+                        ExerciseListItem(
+                            ex = ex,
+                            onEdit = { onEditExercise(it) },
+                            viewModel = viewModel
+                        )
+                    }
                 }
             }
         }
@@ -121,9 +220,31 @@ private fun ExerciseListItem(ex: Exercise, onEdit: (Long) -> Unit, viewModel: Ex
                         .padding(12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    if (ex.imageUri != null) {
+                        AsyncImage(
+                            model = ex.imageUri,
+                            contentDescription = ex.name,
+                            modifier = Modifier.size(56.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.FitnessCenter,
+                            contentDescription = null,
+                            modifier = Modifier.size(56.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                    }
+
                     Column(Modifier.weight(1f)) {
                         Text(ex.name, style = MaterialTheme.typography.titleMedium)
                         Text("${ex.muscle} • ${ex.category.display}", style = MaterialTheme.typography.bodySmall)
+                    }
+                    IconButton(onClick = { viewModel.toggleFavorite(ex) }) {
+                        Icon(
+                            imageVector = if (ex.isFavorite) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                            contentDescription = stringResource(id = if (ex.isFavorite) R.string.favorite_marked else R.string.show_favorites)
+                        )
                     }
                     StarRating(rating = ex.likeability)
                 }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/ExerciseViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/ExerciseViewModel.kt
@@ -31,6 +31,10 @@ class ExerciseViewModel(application: Application) : AndroidViewModel(application
         repo.updateExercise(ex)
     }
 
+    fun toggleFavorite(ex: Exercise) = viewModelScope.launch(Dispatchers.IO) {
+        repo.updateExercise(ex.copy(isFavorite = !ex.isFavorite))
+    }
+
     suspend fun getById(id: Long): Exercise? = withContext(Dispatchers.IO) {
         repo.getExerciseById(id)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,8 +24,13 @@
     <string name="order">Order</string>
     <string name="close">Close</string>
     <string name="search_plans">Search plans</string>
+    <string name="search_exercises">Search exercises</string>
     <string name="show_all">Show all</string>
     <string name="show_favorites">Show favorites</string>
+    <string name="sort_by">Sort by</string>
+    <string name="sort_name">Name (A–Z)</string>
+    <string name="sort_difficulty">Difficulty</string>
+    <string name="sort_muscle_group">Muscle group</string>
     <string name="all">All</string>
     <string name="favorite_marked">Marked as favorite</string>
     <string name="daily">Daily</string>


### PR DESCRIPTION
## Summary
- add `isFavorite` flag to `Exercise`
- provide toggleFavorite method in view model
- extend search bar with customizable placeholder
- support filtering, search, sorting and favorites in `ExercisesScreen`
- bump database version
- add UI strings for sorting and searching

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a9a02328832abc17fa42bd01517d