### PR TITLE
Add user preference screen with plan suggestions

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.example.mygymapp.data.StringListConverter
 import com.example.mygymapp.data.PlanDay
 
 @Database(
@@ -14,10 +15,10 @@ import com.example.mygymapp.data.PlanDay
         Exercise::class,
         PlanDay::class
     ],
-    version = 6,
+    version = 8,
     exportSchema = false
 )
-@TypeConverters(PlanConverters::class)
+@TypeConverters(PlanConverters::class, StringListConverter::class)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun planDao(): PlanDao

--- a/app/src/main/java/com/example/mygymapp/data/Exercise.kt
+++ b/app/src/main/java/com/example/mygymapp/data/Exercise.kt
@@ -14,5 +14,6 @@ data class Exercise(
     val likeability: Int,
     val muscleGroup: MuscleGroup,   // <- model.MuscleGroup
     val muscle: String,
-    val imageUri: String? = null
+    val imageUri: String? = null,
+    val isFavorite: Boolean = false
 )

--- a/app/src/main/java/com/example/mygymapp/data/Plan.kt
+++ b/app/src/main/java/com/example/mygymapp/data/Plan.kt
@@ -3,9 +3,10 @@ package com.example.mygymapp.data
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
+import com.example.mygymapp.data.StringListConverter
 
 @Entity(tableName = "plan")
-@TypeConverters(PlanConverters::class)
+@TypeConverters(PlanConverters::class, StringListConverter::class)
 data class Plan(
     @PrimaryKey(autoGenerate = true)
     val planId: Long = 0L,
@@ -14,7 +15,9 @@ data class Plan(
     val difficulty: Int = 3,
     val isFavorite: Boolean = false,
     val iconUri: String?,
-    val type: PlanType
+    val type: PlanType,
+    val durationMinutes: Int = 30,
+    val requiredEquipment: List<String> = emptyList()
 )
 
 enum class PlanType {

--- a/app/src/main/java/com/example/mygymapp/data/PlanDao.kt
+++ b/app/src/main/java/com/example/mygymapp/data/PlanDao.kt
@@ -10,6 +10,9 @@ interface PlanDao {
     @Query("SELECT * FROM Plan WHERE type = :type ORDER BY name")
     fun getPlansByType(type: PlanType): Flow<List<Plan>>
 
+    @Query("SELECT * FROM Plan")
+    suspend fun getAllPlans(): List<Plan>
+
     @Transaction
     @Query("SELECT * FROM Plan WHERE planId = :id")
     fun getPlanWithExercises(id: Long): PlanWithExercises?

--- a/app/src/main/java/com/example/mygymapp/data/PlanRepository.kt
+++ b/app/src/main/java/com/example/mygymapp/data/PlanRepository.kt
@@ -47,4 +47,12 @@ class PlanRepository(
     /** Löscht einen Plan komplett */
     suspend fun deletePlan(plan: Plan) =
         dao.deletePlan(plan)
+
+    suspend fun getAllPlans(): List<Plan> = dao.getAllPlans()
+
+    suspend fun getSuggestions(prefs: com.example.mygymapp.model.UserPreferences): List<Plan> =
+        getAllPlans().filter { plan ->
+            plan.durationMinutes <= prefs.maxDuration &&
+                plan.requiredEquipment.all { it in prefs.equipment }
+        }
 }

--- a/app/src/main/java/com/example/mygymapp/data/StringListConverter.kt
+++ b/app/src/main/java/com/example/mygymapp/data/StringListConverter.kt
@@ -1,0 +1,13 @@
+package com.example.mygymapp.data
+
+import androidx.room.TypeConverter
+
+class StringListConverter {
+    @TypeConverter
+    fun fromList(value: List<String>): String = value.joinToString(",")
+
+    @TypeConverter
+    fun toList(value: String): List<String> =
+        if (value.isBlank()) emptyList() else value.split(",")
+}
+

--- a/app/src/main/java/com/example/mygymapp/model/Equipment.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Equipment.kt
@@ -1,0 +1,6 @@
+package com.example.mygymapp.model
+
+object Equipment {
+    val options = listOf("Matte", "Kurzhantel", "Pullup Bar", "Widerstandsband", "Keine")
+}
+

--- a/app/src/main/java/com/example/mygymapp/model/UserPreferences.kt
+++ b/app/src/main/java/com/example/mygymapp/model/UserPreferences.kt
@@ -1,0 +1,17 @@
+package com.example.mygymapp.model
+
+/** Temporary user preferences used for plan suggestions */
+data class UserPreferences(
+    val daysPerWeek: Int = 3,
+    val maxDuration: Int = 30,
+    val equipment: Set<String> = emptySet(),
+    val goal: GoalType = GoalType.FIT,
+    val focusGroups: Set<MuscleGroup> = emptySet()
+)
+
+enum class GoalType {
+    HYPERTROPHY,
+    STRENGTH,
+    ENDURANCE,
+    FIT
+}

--- a/app/src/main/java/com/example/mygymapp/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/mygymapp/navigation/NavGraph.kt
@@ -62,6 +62,9 @@ fun AppNavHost(
                 val id = backStackEntry.arguments?.getString("id")?.toLong() ?: return@composable
                 PlanDetailScreen(planId = id, navController = navController)
             }
+            composable("preferences") {
+                PreferenceScreen(navController)
+            }
             composable("workout") { WorkoutScreen() }
             composable("profile") { ProfileScreen(navController) }
             composable("selectTheme") {

--- a/app/src/main/java/com/example/mygymapp/ui/components/PlanDetailSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PlanDetailSheet.kt
@@ -35,6 +35,13 @@ fun PlanDetailSheet(
             DifficultyRating(rating = plan.difficulty)
             Spacer(Modifier.height(8.dp))
 
+            Text(stringResource(id = R.string.duration_label, plan.durationMinutes))
+            Spacer(Modifier.height(4.dp))
+            if (plan.requiredEquipment.isNotEmpty()) {
+                Text(plan.requiredEquipment.joinToString(), style = MaterialTheme.typography.bodySmall)
+                Spacer(Modifier.height(8.dp))
+            }
+
             // Beschreibung
             Text(
                 text = plan.description,

--- a/app/src/main/java/com/example/mygymapp/ui/components/SearchFilterBar.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SearchFilterBar.kt
@@ -17,7 +17,8 @@ fun SearchFilterBar(
     query: String,
     onQueryChange: (String) -> Unit,
     favoritesOnly: Boolean,
-    onFavoritesToggle: () -> Unit
+    onFavoritesToggle: () -> Unit,
+    placeholderRes: Int = R.string.search_plans
 ) {
     Row(
         modifier = Modifier
@@ -29,7 +30,7 @@ fun SearchFilterBar(
         TextField(
             value = query,
             onValueChange = onQueryChange,
-            placeholder = { Text(stringResource(id = R.string.search_plans)) },
+            placeholder = { Text(stringResource(id = placeholderRes)) },
             modifier = Modifier.weight(1f)
         )
         Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/com/example/mygymapp/ui/screens/AddDailyPlanSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/AddDailyPlanSheet.kt
@@ -23,8 +23,12 @@ import androidx.compose.ui.res.stringResource
 import com.example.mygymapp.R
 import com.example.mygymapp.ui.util.move
 import androidx.compose.runtime.saveable.rememberSaveable
+import kotlin.math.roundToInt
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import com.example.mygymapp.model.Equipment
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun AddDailyPlanSheet(
     exercises: List<Exercise>,
@@ -34,6 +38,9 @@ fun AddDailyPlanSheet(
     var name by rememberSaveable { mutableStateOf("") }
     var desc by rememberSaveable { mutableStateOf("") }
     var difficulty by rememberSaveable { mutableIntStateOf(3) }
+
+    var duration by rememberSaveable { mutableIntStateOf(30) }
+    val equipment = remember { mutableStateListOf<String>() }
 
     val selected = remember { mutableStateListOf<ExerciseEntry>() }
 
@@ -71,6 +78,29 @@ fun AddDailyPlanSheet(
             Spacer(Modifier.height(8.dp))
             Text(stringResource(id = R.string.difficulty))
             DifficultyRating(rating = difficulty, onRatingChanged = { difficulty = it })
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.duration_label, duration))
+            Slider(
+                value = duration.toFloat(),
+                onValueChange = { duration = it.roundToInt() },
+                valueRange = 10f..60f
+            )
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.equipment_label))
+            FlowRow {
+                Equipment.options.forEach { eq ->
+                    FilterChip(
+                        selected = eq in equipment,
+                        onClick = {
+                            if (eq in equipment) equipment.remove(eq) else equipment.add(eq)
+                        },
+                        label = { Text(eq) }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
             Spacer(Modifier.height(8.dp))
 
             ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
@@ -151,7 +181,15 @@ fun AddDailyPlanSheet(
                 TextButton(onClick = onCancel) { Text(stringResource(id = R.string.cancel)) }
                 Spacer(Modifier.width(8.dp))
                 Button(onClick = {
-                    val plan = Plan(name = name, description = desc, difficulty = difficulty, iconUri = null, type = PlanType.DAILY)
+                    val plan = Plan(
+                        name = name,
+                        description = desc,
+                        difficulty = difficulty,
+                        iconUri = null,
+                        type = PlanType.DAILY,
+                        durationMinutes = duration,
+                        requiredEquipment = equipment.toList()
+                    )
                     val refs = selected.mapIndexed { idx, e ->
                         PlanExerciseCrossRef(
                             planId = 0L,

--- a/app/src/main/java/com/example/mygymapp/ui/screens/AddWeeklyPlanSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/AddWeeklyPlanSheet.kt
@@ -23,8 +23,12 @@ import androidx.compose.ui.res.stringResource
 import com.example.mygymapp.R
 import androidx.compose.runtime.saveable.rememberSaveable
 import com.example.mygymapp.ui.util.move
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import com.example.mygymapp.model.Equipment
+import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun AddWeeklyPlanSheet(
     exercises: List<Exercise>,
@@ -34,6 +38,9 @@ fun AddWeeklyPlanSheet(
     var name by rememberSaveable { mutableStateOf("") }
     var desc by rememberSaveable { mutableStateOf("") }
     var difficulty by rememberSaveable { mutableIntStateOf(3) }
+
+    var duration by rememberSaveable { mutableIntStateOf(30) }
+    val equipment = remember { mutableStateListOf<String>() }
 
     val dayNames = remember { mutableStateListOf("Tag 1", "Tag 2", "Tag 3", "Tag 4", "Tag 5") }
     val dayEntries = remember { List(5) { mutableStateListOf<ExerciseEntry>() } }
@@ -69,6 +76,29 @@ fun AddWeeklyPlanSheet(
             Spacer(Modifier.height(8.dp))
             Text(stringResource(id = R.string.difficulty))
             DifficultyRating(rating = difficulty, onRatingChanged = { difficulty = it })
+            Spacer(Modifier.height(16.dp))
+
+            Text(stringResource(id = R.string.duration_label, duration))
+            Slider(
+                value = duration.toFloat(),
+                onValueChange = { duration = it.roundToInt() },
+                valueRange = 10f..60f
+            )
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.equipment_label))
+            FlowRow {
+                Equipment.options.forEach { eq ->
+                    FilterChip(
+                        selected = eq in equipment,
+                        onClick = {
+                            if (eq in equipment) equipment.remove(eq) else equipment.add(eq)
+                        },
+                        label = { Text(eq) }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
             Spacer(Modifier.height(16.dp))
 
             dayNames.forEachIndexed { index, dayName ->
@@ -175,7 +205,9 @@ fun AddWeeklyPlanSheet(
                         description = desc,
                         difficulty = difficulty,
                         iconUri = null,
-                        type = PlanType.WEEKLY
+                        type = PlanType.WEEKLY,
+                        durationMinutes = duration,
+                        requiredEquipment = equipment.toList()
                     )
                     val refs = mutableListOf<PlanExerciseCrossRef>()
                     dayEntries.forEachIndexed { day, list ->

--- a/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
@@ -8,15 +8,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.DismissDirection
 import androidx.compose.material.DismissValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -28,15 +31,47 @@ import com.example.mygymapp.viewmodel.ExerciseViewModel
 import com.example.mygymapp.ui.widgets.StarRating
 import com.example.mygymapp.ui.theme.FogGray
 import com.example.mygymapp.ui.theme.PineGreen
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.model.MuscleGroup
+import com.example.mygymapp.ui.components.SearchFilterBar
+import coil.compose.AsyncImage
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.ui.res.stringResource
+import com.example.mygymapp.R
+
+private enum class SortOption(val labelRes: Int, val comparator: Comparator<Exercise>) {
+    NAME(R.string.sort_name, compareBy { it.name.lowercase() }),
+    DIFFICULTY(R.string.sort_difficulty, compareBy { it.likeability }),
+    MUSCLE(R.string.sort_muscle_group, compareBy { it.muscleGroup.display })
+}
 
 @Composable
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 fun ExercisesScreen(
     navController: NavController,
     viewModel: ExerciseViewModel = viewModel(),
     onEditExercise: (Long) -> Unit = {}
 ) {
     val exercises by viewModel.allExercises.observeAsState(emptyList())
+
+    var query by rememberSaveable { mutableStateOf("") }
+    var showFavorites by rememberSaveable { mutableStateOf(false) }
+    var selectedCategory by rememberSaveable { mutableStateOf<ExerciseCategory?>(null) }
+    var selectedGroup by rememberSaveable { mutableStateOf<MuscleGroup?>(null) }
+    var sortExpanded by rememberSaveable { mutableStateOf(false) }
+    var sortOption by rememberSaveable { mutableStateOf(SortOption.NAME) }
+
+    val filtered = exercises
+        .asSequence()
+        .filter { if (showFavorites) it.isFavorite else true }
+        .filter { selectedCategory?.let { cat -> it.category == cat } ?: true }
+        .filter { selectedGroup?.let { grp -> it.muscleGroup == grp } ?: true }
+        .filter { it.name.contains(query, ignoreCase = true) || it.description.contains(query, ignoreCase = true) }
+        .sortedWith(sortOption.comparator)
+        .toList()
     Scaffold(
         containerColor = Color.Transparent,
         floatingActionButton = {
@@ -55,17 +90,83 @@ fun ExercisesScreen(
                 Text("No exercises yet!", style = MaterialTheme.typography.titleMedium)
             }
         } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-            ) {
-                items(exercises, key = { it.id }) { ex ->
-                    ExerciseListItem(
-                        ex = ex,
-                        onEdit = { onEditExercise(it) },
-                        viewModel = viewModel
+            Column(Modifier.padding(paddingValues)) {
+                SearchFilterBar(
+                    query = query,
+                    onQueryChange = { query = it },
+                    favoritesOnly = showFavorites,
+                    onFavoritesToggle = { showFavorites = !showFavorites },
+                    placeholderRes = R.string.search_exercises
+                )
+
+                FlowRow(modifier = Modifier.padding(horizontal = 8.dp)) {
+                    FilterChip(
+                        selected = selectedCategory == null,
+                        onClick = { selectedCategory = null },
+                        label = { Text(stringResource(id = R.string.all)) }
                     )
+                    ExerciseCategory.values().forEach { cat ->
+                        Spacer(Modifier.width(8.dp))
+                        FilterChip(
+                            selected = selectedCategory == cat,
+                            onClick = { selectedCategory = cat },
+                            label = { Text(cat.display) }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(4.dp))
+
+                FlowRow(modifier = Modifier.padding(horizontal = 8.dp)) {
+                    FilterChip(
+                        selected = selectedGroup == null,
+                        onClick = { selectedGroup = null },
+                        label = { Text(stringResource(id = R.string.all)) }
+                    )
+                    MuscleGroup.values().forEach { grp ->
+                        Spacer(Modifier.width(8.dp))
+                        FilterChip(
+                            selected = selectedGroup == grp,
+                            onClick = { selectedGroup = grp },
+                            label = { Text(grp.display) }
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                ExposedDropdownMenuBox(expanded = sortExpanded, onExpandedChange = { sortExpanded = !sortExpanded }) {
+                    OutlinedTextField(
+                        readOnly = true,
+                        value = stringResource(id = sortOption.labelRes),
+                        onValueChange = {},
+                        label = { Text(stringResource(id = R.string.sort_by)) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = sortExpanded) },
+                        modifier = Modifier.menuAnchor().padding(horizontal = 8.dp).fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(expanded = sortExpanded, onDismissRequest = { sortExpanded = false }) {
+                        SortOption.values().forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(id = option.labelRes)) },
+                                onClick = {
+                                    sortOption = option
+                                    sortExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(filtered, key = { it.id }) { ex ->
+                        ExerciseListItem(
+                            ex = ex,
+                            onEdit = { onEditExercise(it) },
+                            viewModel = viewModel
+                        )
+                    }
                 }
             }
         }
@@ -121,9 +222,31 @@ private fun ExerciseListItem(ex: Exercise, onEdit: (Long) -> Unit, viewModel: Ex
                         .padding(12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    if (ex.imageUri != null) {
+                        AsyncImage(
+                            model = ex.imageUri,
+                            contentDescription = ex.name,
+                            modifier = Modifier.size(56.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.FitnessCenter,
+                            contentDescription = null,
+                            modifier = Modifier.size(56.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                    }
+
                     Column(Modifier.weight(1f)) {
                         Text(ex.name, style = MaterialTheme.typography.titleMedium)
                         Text("${ex.muscle} • ${ex.category.display}", style = MaterialTheme.typography.bodySmall)
+                    }
+                    IconButton(onClick = { viewModel.toggleFavorite(ex) }) {
+                        Icon(
+                            imageVector = if (ex.isFavorite) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                            contentDescription = stringResource(id = if (ex.isFavorite) R.string.favorite_marked else R.string.show_favorites)
+                        )
                     }
                     StarRating(rating = ex.likeability)
                 }
@@ -132,6 +255,4 @@ private fun ExerciseListItem(ex: Exercise, onEdit: (Long) -> Unit, viewModel: Ex
         }
     )
 }
-
-
 

--- a/app/src/main/java/com/example/mygymapp/ui/screens/PlansScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/PlansScreen.kt
@@ -1,7 +1,6 @@
 package com.example.mygymapp.ui.screens
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -20,12 +19,17 @@ fun PlansScreen(navController: NavController) {
     val selected = if (tabIndex == 0) PlanType.DAILY else PlanType.WEEKLY
 
     Column(Modifier.fillMaxSize()) {
-        TabRow(selectedTabIndex = tabIndex) {
-            Tab(selected = tabIndex == 0, onClick = { tabIndex = 0 }) {
-                Text(stringResource(id = R.string.daily))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TabRow(selectedTabIndex = tabIndex, modifier = Modifier.weight(1f)) {
+                Tab(selected = tabIndex == 0, onClick = { tabIndex = 0 }) {
+                    Text(stringResource(id = R.string.daily))
+                }
+                Tab(selected = tabIndex == 1, onClick = { tabIndex = 1 }) {
+                    Text(stringResource(id = R.string.weekly))
+                }
             }
-            Tab(selected = tabIndex == 1, onClick = { tabIndex = 1 }) {
-                Text(stringResource(id = R.string.weekly))
+            TextButton(onClick = { navController.navigate("preferences") }) {
+                Text(stringResource(id = R.string.preferences_button))
             }
         }
         if (selected == PlanType.DAILY) {

--- a/app/src/main/java/com/example/mygymapp/ui/screens/PreferenceScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/PreferenceScreen.kt
@@ -1,0 +1,133 @@
+package com.example.mygymapp.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.mygymapp.R
+import com.example.mygymapp.data.AppDatabase
+import com.example.mygymapp.data.PlanRepository
+import com.example.mygymapp.model.Equipment
+import com.example.mygymapp.model.GoalType
+import com.example.mygymapp.model.MuscleGroup
+import com.example.mygymapp.model.UserPreferences
+import com.example.mygymapp.viewmodel.PreferencesViewModel
+import com.example.mygymapp.viewmodel.PreferencesViewModelFactory
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun PreferenceScreen(navController: NavController) {
+    val context = LocalContext.current
+    val repo = remember(context) { PlanRepository(AppDatabase.getDatabase(context).planDao()) }
+    val viewModel: PreferencesViewModel = viewModel(factory = PreferencesViewModelFactory(repo))
+
+    var days by rememberSaveable { mutableIntStateOf(3) }
+    var duration by rememberSaveable { mutableIntStateOf(30) }
+    val equipment = remember { mutableStateListOf<String>() }
+    var goal by rememberSaveable { mutableStateOf(GoalType.FIT) }
+    val groups = remember { mutableStateListOf<MuscleGroup>() }
+
+    val suggestions by viewModel.suggestions.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(id = R.string.preferences_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(id = R.string.back))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            Text(stringResource(id = R.string.days_per_week, days))
+            Slider(value = days.toFloat(), onValueChange = { days = it.roundToInt() }, valueRange = 1f..7f)
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.max_duration_label, duration))
+            Slider(value = duration.toFloat(), onValueChange = { duration = it.roundToInt() }, valueRange = 10f..60f)
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.goal_label))
+            FlowRow {
+                GoalType.values().forEach { g ->
+                    FilterChip(
+                        selected = goal == g,
+                        onClick = { goal = g },
+                        label = { Text(stringResource(id = goalToString(g))) }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.equipment_label))
+            FlowRow {
+                Equipment.options.forEach { eq ->
+                    FilterChip(
+                        selected = eq in equipment,
+                        onClick = {
+                            if (eq in equipment) equipment.remove(eq) else equipment.add(eq)
+                        },
+                        label = { Text(eq) }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+
+            Text(stringResource(id = R.string.focus_groups_label))
+            FlowRow {
+                MuscleGroup.values().forEach { mg ->
+                    FilterChip(
+                        selected = mg in groups,
+                        onClick = {
+                            if (mg in groups) groups.remove(mg) else groups.add(mg)
+                        },
+                        label = { Text(mg.display) }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = {
+                val prefs = UserPreferences(days, duration, equipment.toSet(), goal, groups.toSet())
+                viewModel.loadSuggestions(prefs)
+            }) {
+                Text(stringResource(id = R.string.show_suggestions))
+            }
+            Spacer(Modifier.height(16.dp))
+            suggestions.forEach { plan ->
+                Text(plan.name, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun goalToString(goal: GoalType): Int = when (goal) {
+    GoalType.HYPERTROPHY -> R.string.goal_hypertrophy
+    GoalType.STRENGTH -> R.string.goal_strength
+    GoalType.ENDURANCE -> R.string.goal_endurance
+    GoalType.FIT -> R.string.goal_fit
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/screens/WeeklyPlansTab.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/WeeklyPlansTab.kt
@@ -15,8 +15,10 @@ import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -32,8 +34,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavController
 import com.example.mygymapp.ui.theme.FogGray
 import com.example.mygymapp.ui.theme.PineGreen
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import com.example.mygymapp.model.Equipment
+import com.example.mygymapp.R
+import kotlin.math.roundToInt
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun WeeklyPlansTab(navController: NavController) {
     val context = LocalContext.current
@@ -47,14 +54,45 @@ fun WeeklyPlansTab(navController: NavController) {
     val exercises by exerciseViewModel.allExercises.observeAsState(emptyList())
 
     var showAdd by remember { mutableStateOf(false) }
+    var maxTime by rememberSaveable { mutableIntStateOf(60) }
+    val availableEquipment = remember { mutableStateListOf<String>() }
+
+    val filtered = plans.filter { plan ->
+        plan.durationMinutes <= maxTime &&
+            plan.requiredEquipment.all { it in availableEquipment }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.switchType(PlanType.WEEKLY)
     }
 
-    Box(Modifier.fillMaxSize()) {
-        LazyColumn(Modifier.fillMaxSize().padding(16.dp)) {
-            items(plans, key = { it.planId }) { plan ->
+    Column(Modifier.fillMaxSize()) {
+        Column(Modifier.padding(16.dp)) {
+            Text(stringResource(id = R.string.max_time_filter, maxTime))
+            Slider(
+                value = maxTime.toFloat(),
+                onValueChange = { maxTime = it.roundToInt() },
+                valueRange = 10f..60f
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(stringResource(id = R.string.equipment_filter))
+            FlowRow {
+                Equipment.options.forEach { eq ->
+                    FilterChip(
+                        selected = eq in availableEquipment,
+                        onClick = {
+                            if (eq in availableEquipment) availableEquipment.remove(eq) else availableEquipment.add(eq)
+                        },
+                        label = { Text(eq) }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
+        }
+
+        Box(Modifier.weight(1f)) {
+            LazyColumn(Modifier.fillMaxSize().padding(16.dp)) {
+                items(filtered, key = { it.planId }) { plan ->
                 val dismissState = rememberDismissState(
                     confirmStateChange = {
                         when (it) {
@@ -95,9 +133,10 @@ fun WeeklyPlansTab(navController: NavController) {
                     }
                 )
             }
-        }
-        FloatingActionButton(onClick = { showAdd = true }, modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)) {
-            Icon(Icons.Filled.Add, contentDescription = "Add Plan")
+            }
+            FloatingActionButton(onClick = { showAdd = true }, modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)) {
+                Icon(Icons.Filled.Add, contentDescription = "Add Plan")
+            }
         }
     }
 

--- a/app/src/main/java/com/example/mygymapp/viewmodel/ExerciseViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/ExerciseViewModel.kt
@@ -31,6 +31,10 @@ class ExerciseViewModel(application: Application) : AndroidViewModel(application
         repo.updateExercise(ex)
     }
 
+    fun toggleFavorite(ex: Exercise) = viewModelScope.launch(Dispatchers.IO) {
+        repo.updateExercise(ex.copy(isFavorite = !ex.isFavorite))
+    }
+
     suspend fun getById(id: Long): Exercise? = withContext(Dispatchers.IO) {
         repo.getExerciseById(id)
     }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/PreferencesViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/PreferencesViewModel.kt
@@ -1,0 +1,41 @@
+package com.example.mygymapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.mygymapp.data.PlanRepository
+import com.example.mygymapp.model.UserPreferences
+import com.example.mygymapp.data.Plan
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class PreferencesViewModel(private val repo: PlanRepository) : ViewModel() {
+    private val _prefs = MutableStateFlow(UserPreferences())
+    val prefs: StateFlow<UserPreferences> = _prefs
+
+    private val _suggestions = MutableStateFlow<List<Plan>>(emptyList())
+    val suggestions: StateFlow<List<Plan>> = _suggestions
+
+    fun update(p: UserPreferences) {
+        _prefs.value = p
+    }
+
+    fun loadSuggestions(p: UserPreferences) {
+        _prefs.value = p
+        viewModelScope.launch(Dispatchers.IO) {
+            _suggestions.value = repo.getSuggestions(p)
+        }
+    }
+}
+
+class PreferencesViewModelFactory(private val repo: PlanRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(PreferencesViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return PreferencesViewModel(repo) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,10 +24,19 @@
     <string name="order">Order</string>
     <string name="close">Close</string>
     <string name="search_plans">Search plans</string>
+    <string name="search_exercises">Search exercises</string>
     <string name="show_all">Show all</string>
     <string name="show_favorites">Show favorites</string>
+    <string name="sort_by">Sort by</string>
+    <string name="sort_name">Name (A–Z)</string>
+    <string name="sort_difficulty">Difficulty</string>
+    <string name="sort_muscle_group">Muscle group</string>
     <string name="all">All</string>
     <string name="favorite_marked">Marked as favorite</string>
+    <string name="duration_label">Duration: %1$d min</string>
+    <string name="equipment_label">Equipment</string>
+    <string name="max_time_filter">Max time: %1$d min</string>
+    <string name="equipment_filter">Available equipment</string>
     <string name="daily">Daily</string>
     <string name="weekly">Weekly</string>
     <string name="plan_detail">Plan Details</string>
@@ -61,4 +70,15 @@
     <string name="day_label">Day %1$d</string>
     <string name="app_name">MyGymApp</string>
     <string name="select_theme">Select Theme</string>
+    <string name="preferences_title">Preferences</string>
+    <string name="show_suggestions">Show Suggestions</string>
+    <string name="days_per_week">Days per week: %1$d</string>
+    <string name="max_duration_label">Max duration: %1$d min</string>
+    <string name="goal_label">Goal</string>
+    <string name="focus_groups_label">Focus muscles</string>
+    <string name="goal_hypertrophy">Hypertrophy</string>
+    <string name="goal_strength">Strength</string>
+    <string name="goal_endurance">Endurance</string>
+    <string name="goal_fit">General Fitness</string>
+    <string name="preferences_button">Preferences</string>
 </resources>


### PR DESCRIPTION
## Summary
- create `UserPreferences` data class for capturing workout preferences
- allow database access to get all plans and filter by preferences
- implement `PreferencesViewModel` and `PreferenceScreen` for collecting options
- add navigation route and button from plan tabs to open the preference screen
- update strings with labels for the new screen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a9a02328832abc17fa42bd01517d