### PR TITLE
Add superset grouping support

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
@@ -16,7 +16,7 @@ import com.example.mygymapp.data.ExerciseConverters
         Exercise::class,
         PlanDay::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 @TypeConverters(PlanConverters::class, StringListConverter::class, ExerciseConverters::class)

--- a/app/src/main/java/com/example/mygymapp/data/GroupType.kt
+++ b/app/src/main/java/com/example/mygymapp/data/GroupType.kt
@@ -1,0 +1,7 @@
+package com.example.mygymapp.data
+
+/** Describes grouping of exercises into supersets or circuits. */
+enum class GroupType {
+    SUPERSET,
+    CIRCUIT
+}

--- a/app/src/main/java/com/example/mygymapp/data/PlanConverters.kt
+++ b/app/src/main/java/com/example/mygymapp/data/PlanConverters.kt
@@ -3,6 +3,7 @@ package com.example.mygymapp.data
 import android.net.Uri
 import androidx.room.TypeConverter
 import com.example.mygymapp.data.PlanType
+import com.example.mygymapp.data.GroupType
 
 class PlanConverters {
     @TypeConverter
@@ -16,4 +17,11 @@ class PlanConverters {
 
     @TypeConverter
     fun stringToPlanType(value: String): PlanType = PlanType.valueOf(value)
+
+    @TypeConverter
+    fun groupTypeToString(value: GroupType?): String? = value?.name
+
+    @TypeConverter
+    fun stringToGroupType(value: String?): GroupType? =
+        value?.let { GroupType.valueOf(it) }
 }

--- a/app/src/main/java/com/example/mygymapp/data/PlanExerciseCrossRef.kt
+++ b/app/src/main/java/com/example/mygymapp/data/PlanExerciseCrossRef.kt
@@ -3,6 +3,9 @@ package com.example.mygymapp.data
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+/** Optional grouping for supersets and circuits. */
+import com.example.mygymapp.data.GroupType
+
 @Entity
 data class PlanExerciseCrossRef(
     @PrimaryKey(autoGenerate = true)
@@ -12,5 +15,7 @@ data class PlanExerciseCrossRef(
     val sets: Int,
     val reps: Int,
     val orderIndex: Int,
-    val dayIndex: Int = 0
+    val dayIndex: Int = 0,
+    val groupId: Long? = null,
+    val groupType: GroupType? = null
 )

--- a/app/src/main/java/com/example/mygymapp/model/ExerciseEntry.kt
+++ b/app/src/main/java/com/example/mygymapp/model/ExerciseEntry.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.data.GroupType
 import kotlin.random.Random
 
 /**
@@ -14,7 +15,10 @@ class ExerciseEntry(
     val exercise: Exercise,
     sets: Int = 3,
     reps: Int = 10,
-    val id: Long = Random.nextLong()
+    val id: Long = Random.nextLong(),
+    var groupId: Long? = null,
+    var groupType: GroupType? = null
 ) {
     var sets by mutableIntStateOf(sets)
-    var reps by mutableIntStateOf(reps)}
+    var reps by mutableIntStateOf(reps)
+}

--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
@@ -1,78 +1,51 @@
 package com.example.mygymapp.ui.components
 
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
 import com.example.mygymapp.data.Exercise
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.StarBorder
-
 
 @Composable
 fun ExerciseCard(
-    exercise: Exercise,
+    ex: Exercise,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    onToggleFavorite: () -> Unit
 ) {
     Card(
-        modifier = modifier
-            .padding(vertical = 8.dp, horizontal = 16.dp)
-            .fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        onClick = onClick
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(4.dp)
+            .defaultMinSize(minHeight = 80.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Row(
             Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.Start
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            if (exercise.imageUri != null) {
-                Image(
-                    painter = rememberAsyncImagePainter(exercise.imageUri),
-                    contentDescription = exercise.name,
-                    modifier = Modifier
-                        .size(56.dp)
-                        .clip(RoundedCornerShape(12.dp)),
-                    contentScale = ContentScale.Crop
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Default.FitnessCenter,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.secondary,
-                    modifier = Modifier
-                        .size(56.dp)
-                        .clip(RoundedCornerShape(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(ex.name, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "${ex.muscleGroup.display} • ${ex.category.display}",
+                    style = MaterialTheme.typography.bodySmall
                 )
             }
-            Spacer(Modifier.width(16.dp))
-            Column(Modifier.weight(1f)) {
-                Text(exercise.name, style = MaterialTheme.typography.titleMedium)
-                Text(
-                    "${exercise.category} • ${exercise.muscleGroup}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+            IconButton(onClick = onToggleFavorite) {
+                Icon(
+                    imageVector = if (ex.isFavorite) Icons.Filled.Star else Icons.Outlined.StarBorder,
+                    contentDescription = null
                 )
-                Row {
-                    repeat(5) { i ->
-                        Icon(
-                            imageVector = if (i < exercise.likeability) Icons.Default.Star else Icons.Default.StarBorder,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.secondary,
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
-                }
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/AddDailyPlanSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/AddDailyPlanSheet.kt
@@ -12,6 +12,7 @@ import com.example.mygymapp.data.PlanExerciseCrossRef
 import com.example.mygymapp.data.PlanType
 import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.ui.widgets.DifficultyRating
+import com.example.mygymapp.data.GroupType
 import org.burnoutcrew.reorderable.*
 import com.example.mygymapp.model.ExerciseEntry
 import androidx.compose.foundation.rememberScrollState
@@ -43,6 +44,7 @@ fun AddDailyPlanSheet(
     val equipment = remember { mutableStateListOf<String>() }
 
     val selected = remember { mutableStateListOf<ExerciseEntry>() }
+    val selectedForGroup = remember { mutableStateListOf<Long>() }
 
     var expanded by rememberSaveable { mutableStateOf(false) }
     var chosen by rememberSaveable { mutableStateOf<Exercise?>(null) }
@@ -130,6 +132,20 @@ fun AddDailyPlanSheet(
                 Text(stringResource(id = R.string.add_exercise_button))
             }
 
+            if (selectedForGroup.size >= 2) {
+                Spacer(Modifier.height(8.dp))
+                Button(onClick = {
+                    val gid = System.currentTimeMillis()
+                    selected.filter { it.id in selectedForGroup }.forEach { entry ->
+                        entry.groupId = gid
+                        entry.groupType = GroupType.SUPERSET
+                    }
+                    selectedForGroup.clear()
+                }) {
+                    Text(stringResource(R.string.create_superset))
+                }
+            }
+
             Spacer(Modifier.height(16.dp))
             LazyColumn(
                 state = reorderState.listState,
@@ -145,6 +161,13 @@ fun AddDailyPlanSheet(
                                 .fillMaxWidth()
                                 .padding(8.dp)
                         ) {
+                            Checkbox(
+                                checked = item.id in selectedForGroup,
+                                onCheckedChange = { checked ->
+                                    if (checked) selectedForGroup.add(item.id) else selectedForGroup.remove(item.id)
+                                }
+                            )
+                            Spacer(Modifier.width(4.dp))
                             Text(item.exercise.name, modifier = Modifier.weight(1f))
                             var setsText by remember(item.id) { mutableStateOf(item.sets.toString()) }
                             OutlinedTextField(
@@ -196,7 +219,9 @@ fun AddDailyPlanSheet(
                             exerciseId = e.exercise.id,
                             sets = e.sets,
                             reps = e.reps,
-                            orderIndex = idx
+                            orderIndex = idx,
+                            groupId = e.groupId,
+                            groupType = e.groupType
                         )
                     }
                     onSave(plan, refs)

--- a/app/src/main/java/com/example/mygymapp/ui/screens/AddWeeklyPlanSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/AddWeeklyPlanSheet.kt
@@ -26,6 +26,7 @@ import com.example.mygymapp.ui.util.move
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import com.example.mygymapp.model.Equipment
+import com.example.mygymapp.data.GroupType
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -44,6 +45,7 @@ fun AddWeeklyPlanSheet(
 
     val dayNames = remember { mutableStateListOf("Tag 1", "Tag 2", "Tag 3", "Tag 4", "Tag 5") }
     val dayEntries = remember { List(5) { mutableStateListOf<ExerciseEntry>() } }
+    val selectedForGroup = remember { List(5) { mutableStateListOf<Long>() } }
 
     val dropdownState = remember { mutableStateListOf<Exercise?>(null, null, null, null, null) }
     val expandedList = remember { mutableStateListOf(false, false, false, false, false) }
@@ -163,6 +165,13 @@ fun AddWeeklyPlanSheet(
                                     .fillMaxWidth()
                                     .padding(8.dp)
                             ) {
+                                Checkbox(
+                                    checked = item.id in selectedForGroup[index],
+                                    onCheckedChange = { checked ->
+                                        if (checked) selectedForGroup[index].add(item.id) else selectedForGroup[index].remove(item.id)
+                                    }
+                                )
+                                Spacer(Modifier.width(4.dp))
                                 Text(item.exercise.name, modifier = Modifier.weight(1f))
                                 var setsText by remember(item.id) { mutableStateOf(item.sets.toString()) }
                                 OutlinedTextField(
@@ -193,6 +202,17 @@ fun AddWeeklyPlanSheet(
                         }
                     }
                 }
+                if (selectedForGroup[index].size >= 2) {
+                    Spacer(Modifier.height(4.dp))
+                    Button(onClick = {
+                        val gid = System.currentTimeMillis()
+                        dayEntries[index].filter { it.id in selectedForGroup[index] }.forEach { entry ->
+                            entry.groupId = gid
+                            entry.groupType = GroupType.SUPERSET
+                        }
+                        selectedForGroup[index].clear()
+                    }) { Text(stringResource(R.string.create_superset)) }
+                }
                 Spacer(Modifier.height(12.dp))
             }
 
@@ -219,7 +239,9 @@ fun AddWeeklyPlanSheet(
                                     sets = entry.sets,
                                     reps = entry.reps,
                                     orderIndex = idx,
-                                    dayIndex = day
+                                    dayIndex = day,
+                                    groupId = entry.groupId,
+                                    groupType = entry.groupType
                                 )
                             )
                         }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/EditDailyPlanScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/EditDailyPlanScreen.kt
@@ -25,6 +25,7 @@ import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.data.Plan
 import com.example.mygymapp.data.PlanExerciseCrossRef
 import com.example.mygymapp.data.PlanRepository
+import com.example.mygymapp.data.GroupType
 import com.example.mygymapp.model.ExerciseEntry
 import com.example.mygymapp.ui.util.move
 import com.example.mygymapp.ui.widgets.DifficultyRating
@@ -65,6 +66,7 @@ fun EditDailyPlanScreen(
     var duration by rememberSaveable { mutableIntStateOf(30) }
     val equipment = remember { mutableStateListOf<String>() }
     val selected = remember { mutableStateListOf<ExerciseEntry>() }
+    val selectedForGroup = remember { mutableStateListOf<Long>() }
     var showChooser by remember { mutableStateOf(false) }
     var initialized by remember { mutableStateOf(false) }
 
@@ -80,7 +82,12 @@ fun EditDailyPlanScreen(
             selected.addAll(
                 planWithExercises!!.exercises.sortedBy { it.orderIndex }.mapNotNull { ref ->
                     val ex = exercises.firstOrNull { it.id == ref.exerciseId }
-                    ex?.let { ExerciseEntry(it, ref.sets, ref.reps) }
+                    ex?.let {
+                        ExerciseEntry(it, ref.sets, ref.reps).apply {
+                            groupId = ref.groupId
+                            groupType = ref.groupType
+                        }
+                    }
                 }
             )
             initialized = true
@@ -121,7 +128,9 @@ fun EditDailyPlanScreen(
                                     exerciseId = e.exercise.id,
                                     sets = e.sets,
                                     reps = e.reps,
-                                    orderIndex = idx
+                                    orderIndex = idx,
+                                    groupId = e.groupId,
+                                    groupType = e.groupType
                                 )
                             }
                             viewModel.save(plan, refs)
@@ -212,6 +221,13 @@ fun EditDailyPlanScreen(
                                     .fillMaxWidth()
                                     .padding(8.dp)
                             ) {
+                                Checkbox(
+                                    checked = item.id in selectedForGroup,
+                                    onCheckedChange = { checked ->
+                                        if (checked) selectedForGroup.add(item.id) else selectedForGroup.remove(item.id)
+                                    }
+                                )
+                                Spacer(Modifier.width(4.dp))
                                 Text(item.exercise.name, modifier = Modifier.weight(1f))
                                 var setsText by remember(item.id) { mutableStateOf(item.sets.toString()) }
                                 OutlinedTextField(
@@ -240,6 +256,19 @@ fun EditDailyPlanScreen(
                                 )
                             }
                         }
+                    }
+                }
+                if (selectedForGroup.size >= 2) {
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = {
+                        val gid = System.currentTimeMillis()
+                        selected.filter { it.id in selectedForGroup }.forEach { entry ->
+                            entry.groupId = gid
+                            entry.groupType = GroupType.SUPERSET
+                        }
+                        selectedForGroup.clear()
+                    }) {
+                        Text(stringResource(R.string.create_superset))
                     }
                 }
             }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/ExercisesScreen.kt
@@ -1,55 +1,30 @@
 package com.example.mygymapp.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.outlined.StarBorder
-import androidx.compose.material.icons.filled.FitnessCenter
-import androidx.compose.material.DismissDirection
-import androidx.compose.material.DismissValue
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.SwipeToDismiss
-import androidx.compose.material.rememberDismissState
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import com.example.mygymapp.data.Exercise
-import com.example.mygymapp.viewmodel.ExerciseViewModel
-import com.example.mygymapp.ui.widgets.StarRating
-import com.example.mygymapp.ui.theme.FogGray
-import com.example.mygymapp.ui.theme.PineGreen
-import com.example.mygymapp.model.ExerciseCategory
-import com.example.mygymapp.model.MuscleGroup
-import com.example.mygymapp.ui.components.SearchFilterBar
-import coil.compose.AsyncImage
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
-import androidx.compose.ui.res.stringResource
 import com.example.mygymapp.R
-
-private enum class SortOption(val labelRes: Int, val comparator: Comparator<Exercise>) {
-    NAME(R.string.sort_name, compareBy { it.name.lowercase() }),
-    DIFFICULTY(R.string.sort_difficulty, compareBy { it.likeability }),
-    MUSCLE(R.string.sort_muscle_group, compareBy { it.muscleGroup.display })
-}
+import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.ui.components.ExerciseCard
+import com.example.mygymapp.viewmodel.ExerciseViewModel
 
 @Composable
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 fun ExercisesScreen(
     navController: NavController,
     viewModel: ExerciseViewModel = viewModel(),
@@ -58,113 +33,80 @@ fun ExercisesScreen(
     val exercises by viewModel.allExercises.observeAsState(emptyList())
 
     var query by rememberSaveable { mutableStateOf("") }
-    var showFavorites by rememberSaveable { mutableStateOf(false) }
     var selectedCategory by rememberSaveable { mutableStateOf<ExerciseCategory?>(null) }
-    var selectedGroup by rememberSaveable { mutableStateOf<MuscleGroup?>(null) }
-    var sortExpanded by rememberSaveable { mutableStateOf(false) }
-    var sortOption by rememberSaveable { mutableStateOf(SortOption.NAME) }
+    var searchFocused by remember { mutableStateOf(false) }
 
-    val filtered = exercises
-        .asSequence()
-        .filter { if (showFavorites) it.isFavorite else true }
-        .filter { selectedCategory?.let { cat -> it.category == cat } ?: true }
-        .filter { selectedGroup?.let { grp -> it.muscleGroup == grp } ?: true }
-        .filter { it.name.contains(query, ignoreCase = true) || it.description.contains(query, ignoreCase = true) }
-        .sortedWith(sortOption.comparator)
-        .toList()
+    val filteredExercises = exercises.filter { ex ->
+        ex.name.contains(query, ignoreCase = true) &&
+            (selectedCategory == null || ex.category == selectedCategory)
+    }
+
     Scaffold(
-        containerColor = Color.Transparent,
         floatingActionButton = {
             FloatingActionButton(onClick = { navController.navigate("addExercise") }) {
                 Icon(Icons.Default.Add, contentDescription = "Add Exercise")
             }
         }
     ) { paddingValues ->
-        if (exercises.isEmpty()) {
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                Text("No exercises yet!", style = MaterialTheme.typography.titleMedium)
-            }
-        } else {
-            Column(Modifier.padding(paddingValues)) {
-                SearchFilterBar(
-                    query = query,
-                    onQueryChange = { query = it },
-                    favoritesOnly = showFavorites,
-                    onFavoritesToggle = { showFavorites = !showFavorites },
-                    placeholderRes = R.string.search_exercises
-                )
+        Column(Modifier.fillMaxSize().padding(paddingValues)) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                placeholder = { Text(stringResource(id = R.string.search_exercises)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+                    .onFocusChanged { searchFocused = it.isFocused }
+            )
 
-                FlowRow(modifier = Modifier.padding(horizontal = 8.dp)) {
+            if (searchFocused) {
+                Row(
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .padding(bottom = 4.dp)
+                ) {
                     FilterChip(
                         selected = selectedCategory == null,
                         onClick = { selectedCategory = null },
                         label = { Text(stringResource(id = R.string.all)) }
                     )
-                    ExerciseCategory.values().forEach { cat ->
-                        Spacer(Modifier.width(8.dp))
+                    Spacer(Modifier.width(8.dp))
+                    ExerciseCategory.values().forEachIndexed { index, category ->
+                        if (index != 0) Spacer(Modifier.width(8.dp))
                         FilterChip(
-                            selected = selectedCategory == cat,
-                            onClick = { selectedCategory = cat },
-                            label = { Text(cat.display) }
+                            selected = selectedCategory == category,
+                            onClick = { selectedCategory = category },
+                            label = { Text(category.display) }
                         )
                     }
                 }
+            }
 
-                Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(if (searchFocused) 4.dp else 0.dp))
 
-                FlowRow(modifier = Modifier.padding(horizontal = 8.dp)) {
-                    FilterChip(
-                        selected = selectedGroup == null,
-                        onClick = { selectedGroup = null },
-                        label = { Text(stringResource(id = R.string.all)) }
-                    )
-                    MuscleGroup.values().forEach { grp ->
-                        Spacer(Modifier.width(8.dp))
-                        FilterChip(
-                            selected = selectedGroup == grp,
-                            onClick = { selectedGroup = grp },
-                            label = { Text(grp.display) }
-                        )
-                    }
+            if (filteredExercises.isEmpty()) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("Keine Übungen gefunden")
                 }
-
-                Spacer(Modifier.height(8.dp))
-
-                ExposedDropdownMenuBox(expanded = sortExpanded, onExpandedChange = { sortExpanded = !sortExpanded }) {
-                    OutlinedTextField(
-                        readOnly = true,
-                        value = stringResource(id = sortOption.labelRes),
-                        onValueChange = {},
-                        label = { Text(stringResource(id = R.string.sort_by)) },
-                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = sortExpanded) },
-                        modifier = Modifier.menuAnchor().padding(horizontal = 8.dp).fillMaxWidth()
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(
+                        start = 8.dp,
+                        end = 8.dp,
+                        top = if (searchFocused) 8.dp else 0.dp,
+                        bottom = 8.dp
                     )
-                    ExposedDropdownMenu(expanded = sortExpanded, onDismissRequest = { sortExpanded = false }) {
-                        SortOption.values().forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(stringResource(id = option.labelRes)) },
-                                onClick = {
-                                    sortOption = option
-                                    sortExpanded = false
-                                }
-                            )
-                        }
-                    }
-                }
-
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize()
                 ) {
-                    items(filtered, key = { it.id }) { ex ->
-                        ExerciseListItem(
+                    items(filteredExercises, key = { it.id }) { ex ->
+                        ExerciseCard(
                             ex = ex,
-                            onEdit = { onEditExercise(it) },
-                            viewModel = viewModel
+                            onClick = { onEditExercise(ex.id) },
+                            onToggleFavorite = { viewModel.toggleFavorite(ex) }
                         )
                     }
                 }
@@ -172,87 +114,3 @@ fun ExercisesScreen(
         }
     }
 }
-
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-private fun ExerciseListItem(ex: Exercise, onEdit: (Long) -> Unit, viewModel: ExerciseViewModel) {
-    val dismissState = rememberDismissState(
-        confirmStateChange = {
-            when (it) {
-                DismissValue.DismissedToEnd -> {
-                    viewModel.delete(ex.id)
-                    true
-                }
-                DismissValue.DismissedToStart -> {
-                    onEdit(ex.id)
-                    false
-                }
-                else -> false
-            }
-        }
-    )
-
-    SwipeToDismiss(
-        state = dismissState,
-        directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
-        background = {
-            val direction = dismissState.dismissDirection ?: return@SwipeToDismiss
-            val color = if (direction == DismissDirection.StartToEnd) Color.Red else FogGray
-            val icon = if (direction == DismissDirection.StartToEnd) Icons.Default.Delete else Icons.Default.Edit
-            val alignment = if (direction == DismissDirection.StartToEnd) Alignment.CenterStart else Alignment.CenterEnd
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .background(color)
-                    .padding(horizontal = 20.dp),
-                contentAlignment = alignment
-            ) {
-                Icon(icon, contentDescription = null, tint = PineGreen)
-            }
-        },
-        dismissContent = {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp, horizontal = 8.dp)
-            ) {
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    if (ex.imageUri != null) {
-                        AsyncImage(
-                            model = ex.imageUri,
-                            contentDescription = ex.name,
-                            modifier = Modifier.size(56.dp)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                    } else {
-                        Icon(
-                            imageVector = Icons.Default.FitnessCenter,
-                            contentDescription = null,
-                            modifier = Modifier.size(56.dp)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                    }
-
-                    Column(Modifier.weight(1f)) {
-                        Text(ex.name, style = MaterialTheme.typography.titleMedium)
-                        Text("${ex.muscle} • ${ex.category.display}", style = MaterialTheme.typography.bodySmall)
-                    }
-                    IconButton(onClick = { viewModel.toggleFavorite(ex) }) {
-                        Icon(
-                            imageVector = if (ex.isFavorite) Icons.Filled.Star else Icons.Outlined.StarBorder,
-                            contentDescription = stringResource(id = if (ex.isFavorite) R.string.favorite_marked else R.string.show_favorites)
-                        )
-                    }
-                    StarRating(rating = ex.likeability)
-                }
-
-            }
-        }
-    )
-}
-

--- a/app/src/main/java/com/example/mygymapp/ui/screens/StepWorkoutScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/StepWorkoutScreen.kt
@@ -1,0 +1,170 @@
+package com.example.mygymapp.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.R
+import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.data.PlanExerciseCrossRef
+import com.example.mygymapp.data.GroupType
+
+class WorkoutSet(reps: Int = 0, done: Boolean = false) {
+    var reps by mutableIntStateOf(reps)
+    var done by mutableStateOf(done)
+}
+
+class WorkoutExerciseState(
+    val ref: PlanExerciseCrossRef,
+    val sets: SnapshotStateList<WorkoutSet> = mutableStateListOf(),
+    notes: String = ""
+) {
+    var notes by mutableStateOf(notes)
+}
+
+@Composable
+fun StepWorkoutScreen(
+    exercises: List<PlanExerciseCrossRef>,
+    getExerciseInfo: (Long) -> Exercise,
+    onComplete: () -> Unit
+) {
+    var currentIndex by remember { mutableIntStateOf(0) }
+    val workoutExercises = remember(exercises) {
+        exercises.map { ref ->
+            WorkoutExerciseState(
+                ref = ref,
+                sets = mutableStateListOf<WorkoutSet>().apply {
+                    repeat(ref.sets) { add(WorkoutSet(reps = ref.reps)) }
+                }
+            )
+        }
+    }
+
+    if (exercises.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    stringResource(R.string.no_exercises_today),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = onComplete) { Text(stringResource(R.string.finish_day)) }
+            }
+        }
+        return
+    }
+
+    val state = workoutExercises.getOrNull(currentIndex)
+    if (state != null) {
+        val ex = getExerciseInfo(state.ref.exerciseId)
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                "Übung ${currentIndex + 1} / ${exercises.size}",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(Modifier.height(8.dp))
+
+            Text(ex.name, style = MaterialTheme.typography.headlineMedium)
+            Text("${state.ref.sets} × ${state.ref.reps}", style = MaterialTheme.typography.bodyLarge)
+            Text("${ex.muscleGroup.display} • ${ex.category.display}", style = MaterialTheme.typography.bodySmall)
+            state.ref.groupType?.let { gt ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    when (gt) {
+                        GroupType.SUPERSET -> stringResource(R.string.superset)
+                        GroupType.CIRCUIT -> stringResource(R.string.circuit)
+                    },
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Column {
+                state.sets.forEachIndexed { index, set ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    ) {
+                        Text("${index + 1}.")
+                        Spacer(Modifier.width(8.dp))
+                        OutlinedTextField(
+                            value = if (set.reps == 0) "" else set.reps.toString(),
+                            onValueChange = { text -> set.reps = text.toIntOrNull() ?: 0 },
+                            label = { Text(stringResource(R.string.reps)) },
+                            modifier = Modifier.width(60.dp)
+                        )
+                        Spacer(Modifier.weight(1f))
+                        Checkbox(
+                            checked = set.done,
+                            onCheckedChange = { set.done = it }
+                        )
+                    }
+                }
+
+                Button(onClick = { state.sets.add(WorkoutSet()) }) {
+                    Text(stringResource(R.string.add_set))
+                }
+
+                Spacer(Modifier.height(8.dp))
+                val total = state.sets.sumOf { it.reps }
+                Text(stringResource(R.string.total_reps, total))
+
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = state.notes,
+                    onValueChange = { state.notes = it },
+                    label = { Text(stringResource(R.string.notes)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                if (currentIndex > 0) {
+                    Button(onClick = { currentIndex-- }) { Text(stringResource(R.string.back)) }
+                } else {
+                    Spacer(Modifier.width(1.dp))
+                }
+
+                Button(onClick = {
+                    if (currentIndex == exercises.lastIndex) {
+                        onComplete()
+                    } else {
+                        currentIndex++
+                    }
+                }) {
+                    val label = if (currentIndex == exercises.lastIndex) {
+                        stringResource(R.string.finish_day)
+                    } else {
+                        stringResource(R.string.next)
+                    }
+                    Text(label)
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/screens/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/WorkoutScreen.kt
@@ -110,7 +110,12 @@ fun WorkoutScreen(viewModel: WorkoutViewModel = viewModel()) {
                         nav.navigate("FinishDay")
                     }
                 } else {
-                    WorkoutDayScreen(plan = plan, state = state, viewModel = viewModel) {
+                    StepWorkoutScreen(
+                        exercises = plan?.exercises
+                            ?.filter { it.dayIndex == calculatePlanIndex(state) }
+                            ?.sortedBy { it.orderIndex } ?: emptyList(),
+                        getExerciseInfo = { id -> viewModel.getExerciseById(id) }
+                    ) {
                         viewModel.finishDay()
                         nav.navigate("FinishDay")
                     }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/WorkoutViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/WorkoutViewModel.kt
@@ -14,6 +14,8 @@ import com.example.mygymapp.model.WeekProgress
 import com.example.mygymapp.model.PlanType
 import com.example.mygymapp.data.ExerciseRepository
 import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.model.MuscleGroup
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.NoSuchElementException
@@ -114,6 +116,12 @@ class WorkoutViewModel(application: Application) : AndroidViewModel(application)
 
     fun getExerciseGroup(id: Long): String =
         exercises.value?.firstOrNull { it.id == id }?.muscleGroup?.display ?: ""
+
+    fun getExerciseById(id: Long): Exercise =
+        exercises.value?.firstOrNull { it.id == id } ?: Exercise(
+            name = "Unbekannt", description = "", category = ExerciseCategory.Calisthenics,
+            likeability = 1, muscleGroup = MuscleGroup.Core, muscle = "", id = id
+        )
 
     fun loadPlan(planId: Long): LiveData<PlanWithExercises> {
         val result = MutableLiveData<PlanWithExercises>()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,11 @@
     <string name="no_suggestions">No matching plans found</string>
     <string name="generate_plan">Generate Plan</string>
     <string name="setup_week">Setup Week</string>
+    <string name="no_exercises_today">No exercises today</string>
+    <string name="add_set">Add Set</string>
+    <string name="total_reps">Total Reps: %1$d</string>
+    <string name="notes">Notes</string>
+    <string name="superset">Superset</string>
+    <string name="circuit">Circuit</string>
+    <string name="create_superset">Create Superset</string>
 </resources>


### PR DESCRIPTION
## Summary
- extend PlanExerciseCrossRef with group info and add GroupType enum
- expose GroupType through converters and bump database version
- show group labels in StepWorkoutScreen
- allow selecting exercises in EditDailyPlanScreen to create a superset
- support creating supersets when adding or editing weekly/daily plans

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cba9c340832a979d2f3a1b0a7a92