### PR TITLE
Enhance navigation with pager indicator and modern FAB

### DIFF
--- a/app/src/main/java/com/example/mygymapp/components/PlanCard.kt
+++ b/app/src/main/java/com/example/mygymapp/components/PlanCard.kt
@@ -2,6 +2,9 @@ package com.example.mygymapp.components
 
 import android.net.Uri
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.LocalIndication
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
@@ -16,9 +19,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.Image
 import coil.compose.rememberAsyncImagePainter
@@ -33,10 +38,17 @@ fun PlanCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .padding(4.dp)
+            .indication(interactionSource, LocalIndication.current)
+            .clickable(
+                onClick = onClick,
+                interactionSource = interactionSource,
+                indication = null
+            ),
         colors = CardDefaults.cardColors(containerColor = Color.White),
         shape = RoundedCornerShape(12.dp),
         elevation = CardDefaults.cardElevation(4.dp)

--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
@@ -1,13 +1,17 @@
 package com.example.mygymapp.ui.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.LocalIndication
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
@@ -19,12 +23,18 @@ fun ExerciseCard(
     onClick: () -> Unit,
     onToggleFavorite: () -> Unit
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(4.dp)
             .defaultMinSize(minHeight = 80.dp)
-            .clickable(onClick = onClick),
+            .indication(interactionSource, LocalIndication.current)
+            .clickable(
+                onClick = onClick,
+                interactionSource = interactionSource,
+                indication = null
+            ),
         shape = RoundedCornerShape(12.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {

--- a/app/src/main/java/com/example/mygymapp/ui/components/StarRating.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/StarRating.kt
@@ -1,21 +1,26 @@
 package com.example.mygymapp.ui.components
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalIndication
 
 
 
 @Composable
 fun StarRating(rating: Int, onRatingChanged: (Int) -> Unit, modifier: Modifier = Modifier) {
     Row(modifier) {
+        val interactionSource = remember { MutableInteractionSource() }
         for (i in 1..5) {
             Icon(
                 imageVector = if (i <= rating) Icons.Filled.Star else Icons.Filled.StarBorder,
@@ -23,7 +28,12 @@ fun StarRating(rating: Int, onRatingChanged: (Int) -> Unit, modifier: Modifier =
                 tint = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier
                     .size(32.dp)
-                    .clickable { onRatingChanged(i) }
+                    .indication(interactionSource, LocalIndication.current)
+                    .clickable(
+                        onClick = { onRatingChanged(i) },
+                        interactionSource = interactionSource,
+                        indication = null
+                    )
             )
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/MainScreen.kt
@@ -1,17 +1,20 @@
 package com.example.mygymapp.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.background
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import com.google.accompanist.pager.HorizontalPagerIndicator
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FitnessCenter
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -19,10 +22,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import com.example.mygymapp.R
 
 @Composable
 fun MainScreen(navController: NavHostController) {
     val pagerState = rememberPagerState()
+    val haptics = LocalHapticFeedback.current
 
     Box(
         modifier = Modifier
@@ -43,16 +51,42 @@ fun MainScreen(navController: NavHostController) {
             }
         }
 
-        FloatingActionButton(
-            onClick = { navController.navigate("exercises") },
+        HorizontalPagerIndicator(
+            pagerState = pagerState,
             modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(24.dp),
-            containerColor = Color(0xFF4B6E4D),
-            contentColor = Color.White,
-            elevation = FloatingActionButtonDefaults.elevation(8.dp)
-        ) {
-            Icon(Icons.Default.FitnessCenter, contentDescription = "Zu Übungen")
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 32.dp),
+            activeColor = MaterialTheme.colorScheme.primary
+        )
+
+        if (pagerState.currentPage == 1) {
+            ExtendedFloatingActionButton(
+                onClick = {
+                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    navController.navigate("exercises")
+                },
+                text = { Text(stringResource(id = R.string.add_plan)) },
+                icon = { Icon(Icons.Default.FitnessCenter, contentDescription = null) },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(24.dp),
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = Color.White
+            )
+        } else {
+            FloatingActionButton(
+                onClick = {
+                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    navController.navigate("exercises")
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(24.dp),
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = Color.White
+            ) {
+                Icon(Icons.Default.FitnessCenter, contentDescription = "Übungen")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/widgets/DifficultyRating.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/widgets/DifficultyRating.kt
@@ -1,12 +1,16 @@
 package com.example.mygymapp.ui.widgets
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.LocalIndication
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Eco
 import androidx.compose.material.icons.outlined.Eco
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 
 @Composable
@@ -17,13 +21,19 @@ fun DifficultyRating(
     max: Int = 5
 ) {
     Row(modifier) {
+        val interactionSource = remember { MutableInteractionSource() }
         repeat(max) { i ->
             val icon = if (i < rating) Icons.Filled.Eco else Icons.Outlined.Eco
             Icon(
                 imageVector = icon,
                 contentDescription = null,
                 modifier = Modifier
-                    .clickable(enabled = onRatingChanged != null) { onRatingChanged?.invoke(i + 1) }
+                    .indication(interactionSource, LocalIndication.current)
+                    .clickable(
+                        enabled = onRatingChanged != null,
+                        interactionSource = interactionSource,
+                        indication = null
+                    ) { onRatingChanged?.invoke(i + 1) }
             )
         }
     }


### PR DESCRIPTION
## Summary
- modernize floating action button with Material theme colors
- add horizontal pager indicator on `MainScreen`
- provide haptic feedback when opening exercises
- show extended FAB on plans page
- add ripple indication to cards and rating widgets

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc83bc118832ab483262416b9b91d