### PR TITLE
Improve theme and navigation

### DIFF
--- a/app/src/main/java/com/example/mygymapp/MainActivity.kt
+++ b/app/src/main/java/com/example/mygymapp/MainActivity.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import com.example.mygymapp.navigation.BottomNavBar
 import com.example.mygymapp.navigation.AppNavHost
 import com.example.mygymapp.ui.theme.MyGymAppTheme
 
@@ -13,7 +17,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             val navController = rememberNavController()
             MyGymAppTheme {
-                AppNavHost(navController = navController)
+                Scaffold(bottomBar = { BottomNavBar(navController) }) { padding ->
+                    AppNavHost(navController = navController, modifier = Modifier.padding(padding))
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/components/PlanCard.kt
+++ b/app/src/main/java/com/example/mygymapp/components/PlanCard.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardDefaults.cardColors
 import androidx.compose.material3.CardDefaults.cardElevation
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -23,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.Image
 import coil.compose.rememberAsyncImagePainter
@@ -50,8 +48,8 @@ fun PlanCard(
                 interactionSource = interactionSource,
                 indication = null
             ),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
-        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        shape = MaterialTheme.shapes.medium,
         elevation = CardDefaults.cardElevation(4.dp)
     ) {
         Row(

--- a/app/src/main/java/com/example/mygymapp/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/example/mygymapp/navigation/BottomNavBar.kt
@@ -1,0 +1,39 @@
+package com.example.mygymapp.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FitnessCenter
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.example.mygymapp.R
+
+sealed class BottomNavItem(val route: String, val icon: ImageVector, val label: Int) {
+    object Home : BottomNavItem("main", Icons.Outlined.Home, R.string.home)
+    object Exercises : BottomNavItem("exercises", Icons.Outlined.FitnessCenter, R.string.exercises)
+}
+
+@Composable
+fun BottomNavBar(navController: NavController) {
+    val items = listOf(BottomNavItem.Home, BottomNavItem.Exercises)
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    NavigationBar {
+        items.forEach { item ->
+            NavigationBarItem(
+                selected = currentRoute == item.route,
+                onClick = { navController.navigate(item.route) { launchSingleTop = true } },
+                icon = { Icon(item.icon, contentDescription = null) },
+                label = { Text(stringResource(id = item.label)) }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/components/AddEditExerciseSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/AddEditExerciseSheet.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.example.mygymapp.ui.widgets.DifficultyRating
+import com.example.mygymapp.ui.components.PrimaryButton
 import androidx.compose.ui.res.stringResource
 import com.example.mygymapp.R
 
@@ -75,7 +76,7 @@ fun AddEditExerciseSheet(
                         contentDescription = stringResource(id = R.string.exercise_image),
                         modifier = Modifier
                             .size(64.dp)
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(MaterialTheme.shapes.medium)
                     )
                     Spacer(Modifier.width(8.dp))
                 }
@@ -102,17 +103,15 @@ fun AddEditExerciseSheet(
             StarRating(rating = rating, onRatingChanged = { rating = it })
             Spacer(Modifier.height(24.dp))
             Row {
-                Button(
+                PrimaryButton(
                     onClick = {
                         if (name.isNotBlank() && category.isNotBlank() && muscleGroup.isNotBlank()) {
                             onSave(name, category, muscleGroup, rating, imageUri)
                         }
                     },
-                    enabled = name.isNotBlank() && category.isNotBlank() && muscleGroup.isNotBlank(),
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(stringResource(id = R.string.save))
-                }
+                    modifier = Modifier.weight(1f),
+                    textRes = R.string.save
+                )
                 Spacer(Modifier.width(12.dp))
                 OutlinedButton(onClick = onCancel, modifier = Modifier.weight(1f)) {
                     Text(stringResource(id = R.string.cancel))

--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.StarBorder
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -35,7 +34,8 @@ fun ExerciseCard(
                 interactionSource = interactionSource,
                 indication = null
             ),
-        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        shape = MaterialTheme.shapes.medium,
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Row(

--- a/app/src/main/java/com/example/mygymapp/ui/components/PlanDetailSheet.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PlanDetailSheet.kt
@@ -10,6 +10,7 @@ import com.example.mygymapp.ui.widgets.DifficultyRating
 import com.example.mygymapp.data.PlanDay
 import androidx.compose.ui.res.stringResource
 import com.example.mygymapp.R
+import com.example.mygymapp.ui.components.PrimaryButton
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,12 +74,11 @@ fun PlanDetailSheet(
             }
 
             Spacer(Modifier.height(24.dp))
-            Button(
+            PrimaryButton(
                 onClick = onClose,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(stringResource(id = R.string.close))
-            }
+                modifier = Modifier.fillMaxWidth(),
+                textRes = R.string.close
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/components/PrimaryButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PrimaryButton.kt
@@ -1,0 +1,28 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.material3.MaterialTheme
+
+@Composable
+fun PrimaryButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    textRes: Int
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        )
+    ) {
+        Text(stringResource(id = textRes), style = MaterialTheme.typography.labelLarge)
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/components/SearchFilterBar.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SearchFilterBar.kt
@@ -36,7 +36,7 @@ fun SearchFilterBar(
         Spacer(Modifier.width(8.dp))
         IconButton(onClick = onFavoritesToggle) {
             Icon(
-                imageVector = if (favoritesOnly) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                imageVector = if (favoritesOnly) Icons.Outlined.Star else Icons.Outlined.StarOutline,
                 contentDescription = if (favoritesOnly) stringResource(id = R.string.show_all) else stringResource(id = R.string.show_favorites)
 
             )

--- a/app/src/main/java/com/example/mygymapp/ui/screens/DailyPlansTab.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/DailyPlansTab.kt
@@ -29,9 +29,8 @@ import com.example.mygymapp.viewmodel.PlansViewModel
 import com.example.mygymapp.viewmodel.PlansViewModelFactory
 import com.example.mygymapp.viewmodel.ExerciseViewModel
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.MaterialTheme
 import androidx.navigation.NavController
-import com.example.mygymapp.ui.theme.FogGray
 import com.example.mygymapp.ui.theme.PineGreen
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -118,7 +117,7 @@ fun DailyPlansTab(navController: NavController) {
                     directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
                     background = {
                         val dir = dismissState.dismissDirection ?: return@SwipeToDismiss
-                        val color = if (dir == DismissDirection.StartToEnd) Color.Red else FogGray
+                        val color = if (dir == DismissDirection.StartToEnd) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
                         val icon = if (dir == DismissDirection.StartToEnd) Icons.Outlined.Delete else Icons.Outlined.Edit
                         val align = if (dir == DismissDirection.StartToEnd) Alignment.CenterStart else Alignment.CenterEnd
                         Box(

--- a/app/src/main/java/com/example/mygymapp/ui/screens/ExerciseListScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/ExerciseListScreen.kt
@@ -77,8 +77,8 @@ fun ExerciseListScreen(
                             ),
                             background = {
                                 val color = when (dismissState.dismissDirection) {
-                                    DismissDirection.StartToEnd -> Color.Red
-                                    DismissDirection.EndToStart -> Color.Yellow
+                                    DismissDirection.StartToEnd -> MaterialTheme.colorScheme.error
+                                    DismissDirection.EndToStart -> MaterialTheme.colorScheme.primary
                                     else -> Color.Transparent
                                 }
                                 Box(

--- a/app/src/main/java/com/example/mygymapp/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/MainScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.outlined.FitnessCenter
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
@@ -16,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
@@ -55,11 +54,11 @@ fun MainScreen(navController: NavHostController) {
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(24.dp),
-            containerColor = Color(0xFF4B6E4D),
-            contentColor = Color.White,
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
             elevation = FloatingActionButtonDefaults.elevation(8.dp)
         ) {
-            Icon(Icons.Filled.FitnessCenter, contentDescription = "Übungen")
+            Icon(Icons.Outlined.FitnessCenter, contentDescription = "Übungen")
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/screens/WeeklyPlansTab.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/WeeklyPlansTab.kt
@@ -30,9 +30,8 @@ import com.example.mygymapp.viewmodel.PlansViewModel
 import com.example.mygymapp.viewmodel.PlansViewModelFactory
 import com.example.mygymapp.viewmodel.ExerciseViewModel
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.MaterialTheme
 import androidx.navigation.NavController
-import com.example.mygymapp.ui.theme.FogGray
 import com.example.mygymapp.ui.theme.PineGreen
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -113,7 +112,7 @@ fun WeeklyPlansTab(navController: NavController) {
                     directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
                     background = {
                         val dir = dismissState.dismissDirection ?: return@SwipeToDismiss
-                        val color = if (dir == DismissDirection.StartToEnd) Color.Red else FogGray
+                        val color = if (dir == DismissDirection.StartToEnd) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
                         val icon = if (dir == DismissDirection.StartToEnd) Icons.Outlined.Delete else Icons.Outlined.Edit
                         val align = if (dir == DismissDirection.StartToEnd) Alignment.CenterStart else Alignment.CenterEnd
                         Box(

--- a/app/src/main/java/com/example/mygymapp/ui/theme/MyGymAppTheme.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/MyGymAppTheme.kt
@@ -2,35 +2,17 @@ package com.example.mygymapp.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import com.example.mygymapp.ui.theme.MyGymColorScheme.DarkColors
+import com.example.mygymapp.ui.theme.MyGymColorScheme.LightColors
+import com.example.mygymapp.ui.theme.AppShapes
 
 @Composable
 fun MyGymAppTheme(content: @Composable () -> Unit) {
-    val lightColors = lightColorScheme(
-        primary = PrimaryGreen,
-        secondary = SecondaryGreen,
-        background = LightBackground,
-        surface = Color.White,
-        onPrimary = Color.White,
-        onSecondary = Color.White,
-        onBackground = TextPrimary,
-        onSurface = TextPrimary,
-        error = ErrorRed
+    val colors = if (isSystemInDarkTheme()) DarkColors else LightColors
+    MaterialTheme(
+        colorScheme = colors,
+        shapes = AppShapes,
+        content = content
     )
-    val darkColors = darkColorScheme(
-        primary = PrimaryGreen,
-        secondary = SecondaryGreen,
-        background = DarkBackground,
-        surface = DarkBackground,
-        onPrimary = Color.White,
-        onSecondary = Color.White,
-        onBackground = Color.White,
-        onSurface = Color.White,
-        error = ErrorRed
-    )
-    val colors = if (isSystemInDarkTheme()) darkColors else lightColors
-    MaterialTheme(colorScheme = colors, content = content)
 }

--- a/app/src/main/java/com/example/mygymapp/ui/theme/MyGymColorScheme.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/MyGymColorScheme.kt
@@ -1,0 +1,31 @@
+package com.example.mygymapp.ui.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+
+object MyGymColorScheme {
+    val LightColors = lightColorScheme(
+        primary = PrimaryGreen,
+        secondary = SecondaryGreen,
+        background = LightBackground,
+        surface = Color.White,
+        onPrimary = Color.White,
+        onSecondary = Color.White,
+        onBackground = TextPrimary,
+        onSurface = TextPrimary,
+        error = ErrorRed
+    )
+
+    val DarkColors = darkColorScheme(
+        primary = PrimaryGreen,
+        secondary = SecondaryGreen,
+        background = DarkBackground,
+        surface = DarkBackground,
+        onPrimary = Color.White,
+        onSecondary = Color.White,
+        onBackground = Color.White,
+        onSurface = Color.White,
+        error = ErrorRed
+    )
+}

--- a/app/src/main/java/com/example/mygymapp/ui/theme/Shapes.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/Shapes.kt
@@ -1,0 +1,11 @@
+package com.example.mygymapp.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val AppShapes = Shapes(
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(0.dp)
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,4 +103,6 @@
     <string name="goal_reps_label">Goal Reps</string>
     <string name="current_pr_label">Current PR: %1$d</string>
     <string name="goal_progress">%1$d%% of your goal reached</string>
+    <string name="home">Home</string>
+    <string name="exercises">Exercises</string>
 </resources>


### PR DESCRIPTION
## Summary
- centralize color scheme and shapes
- add reusable `PrimaryButton` component
- refactor cards and screens to use theme colors and shapes
- switch icons to `Outlined` set
- add bottom navigation bar with labels

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e209cef4c832aaeb9cf2e87682485