### PR TITLE
Add new Home screen

### DIFF
--- a/app/src/main/java/com/example/mygymapp/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/mygymapp/navigation/AppNavHost.kt
@@ -10,14 +10,16 @@ import com.example.mygymapp.ui.screens.WorkoutScreen
 import com.example.mygymapp.ui.screens.ProgressScreen
 import com.example.mygymapp.ui.screens.ProfileScreen
 import com.example.mygymapp.ui.screens.PlansScreen
+import com.example.mygymapp.ui.screens.HomeScreen
 
 @Composable
 fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
     NavHost(
         navController = navController,
-        startDestination = "workout",
+        startDestination = "main",
         modifier = modifier
     ) {
+        composable("main") { HomeScreen() }
         composable("workout") { WorkoutScreen() }
         composable("progress") { ProgressScreen() }
         composable("exercises") { ExercisesScreen(navController) }

--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionHeader.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionHeader.kt
@@ -1,0 +1,17 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SectionHeader(title: String, modifier: Modifier = Modifier) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = modifier.padding(vertical = 8.dp)
+    )
+}

--- a/app/src/main/java/com/example/mygymapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/screens/HomeScreen.kt
@@ -1,0 +1,188 @@
+package com.example.mygymapp.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.mygymapp.ui.components.SectionHeader
+import com.example.mygymapp.viewmodel.HomeViewModel
+import com.example.mygymapp.R
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Composable
+fun HomeScreen(viewModel: HomeViewModel = viewModel()) {
+    val todayPlan = viewModel.todayPlan.collectAsState()
+    val progress = viewModel.progress.collectAsState()
+    val history = viewModel.history.collectAsState()
+    val ctx = LocalDate.now(ZoneId.systemDefault())
+    val startOfWeek = ctx.with(DayOfWeek.MONDAY)
+
+    val selectedDate: MutableState<LocalDate?> = remember { mutableStateOf(null) }
+    val entryInfo = remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    LaunchedEffect(selectedDate.value) {
+        val date = selectedDate.value ?: return@LaunchedEffect
+        val entry = history.value[date]
+        entryInfo.value = entry?.let { viewModel.getEntryInfo(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item {
+                SectionHeader(title = "Was steht heute an?")
+                if (todayPlan.value != null && progress.value != null) {
+                    val idx = calculatePlanIndex(progress.value!!)
+                    val exercises = todayPlan.value!!.exercises.filter { it.dayIndex == idx }
+                    val groups = exercises.map { viewModel.getExerciseGroup(it.exerciseId) }
+                        .distinct()
+                        .joinToString()
+                    Text(
+                        text = stringResource(
+                            id = R.string.home_today,
+                            todayPlan.value!!.plan.name,
+                            exercises.size,
+                            todayPlan.value!!.plan.durationMinutes
+                        )
+                    )
+                    if (groups.isNotBlank()) {
+                        Text(stringResource(id = R.string.home_goal, groups))
+                    }
+                    Button(onClick = { /* TODO start workout */ }) {
+                        Text(stringResource(id = R.string.home_start_workout))
+                    }
+                } else {
+                    Text(stringResource(id = R.string.home_no_plan))
+                    Button(onClick = { /* TODO choose plan */ }) {
+                        Text(stringResource(id = R.string.home_choose_plan))
+                    }
+                }
+            }
+            item { Divider() }
+            item {
+                SectionHeader(title = "Letztes Workout")
+                val last = viewModel.lastWorkout
+                if (last != null) {
+                    val info = entryInfo.value
+                    val planName = info?.first ?: ""
+                    val dayName = info?.second ?: ""
+                    Text(stringResource(id = R.string.home_last_active, dayName, planName))
+                } else {
+                    Text(stringResource(id = R.string.home_no_workout))
+                }
+            }
+            item { Divider() }
+            item {
+                SectionHeader(title = "Woche")
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    tonalElevation = 1.dp
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        for (i in 0..6) {
+                            val date = startOfWeek.plusDays(i.toLong())
+                            val symbol = when {
+                                history.value.containsKey(date) -> "✅"
+                                progress.value?.restDay == i -> "🌙"
+                                i == 5 && progress.value?.modularRest == true -> "🌙"
+                                date.isBefore(ctx) -> "❌"
+                                else -> "⬜"
+                            }
+                            Text(
+                                text = symbol,
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .clickable { selectedDate.value = date },
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                }
+            }
+            item { Divider() }
+            item {
+                SectionHeader(title = "Fortschritt")
+                Text(stringResource(id = R.string.home_streak, viewModel.workoutStreak))
+                Text(stringResource(id = R.string.home_week_progress, viewModel.workoutsThisWeek, 5))
+                Button(onClick = { /* TODO open progress */ }) {
+                    Text(stringResource(id = R.string.home_view_progress))
+                }
+            }
+            item { Divider() }
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally)
+                ) {
+                    Button(onClick = { /* TODO start workout */ }) {
+                        Text(stringResource(id = R.string.home_start_workout))
+                    }
+                    Button(onClick = { /* TODO open progress */ }) {
+                        Text(stringResource(id = R.string.home_view_progress))
+                    }
+                }
+            }
+        }
+        if (selectedDate.value != null) {
+            AlertDialog(
+                onDismissRequest = { selectedDate.value = null },
+                confirmButton = {
+                    Button(onClick = { selectedDate.value = null }) {
+                        Text(stringResource(id = R.string.close))
+                    }
+                },
+                title = { Text(selectedDate.value.toString()) },
+                text = {
+                    val info = entryInfo.value
+                    if (info != null) {
+                        Text("${info.second} – ${info.first}")
+                    } else {
+                        Text(stringResource(id = R.string.home_no_workout))
+                    }
+                }
+            )
+        }
+    }
+}
+
+private fun calculatePlanIndex(state: WeekProgress): Int {
+    var idx = state.day
+    if (state.restDay in 0..6 && state.day > state.restDay) idx--
+    if (state.day > 5) idx--
+    return idx
+}

--- a/app/src/main/java/com/example/mygymapp/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/HomeViewModel.kt
@@ -1,0 +1,105 @@
+package com.example.mygymapp.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mygymapp.data.AppDatabase
+import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.data.ExerciseRepository
+import com.example.mygymapp.data.PlanRepository
+import com.example.mygymapp.data.PlanWithExercises
+import com.example.mygymapp.data.WorkoutHistoryEntry
+import com.example.mygymapp.data.WorkoutHistoryStorage
+import com.example.mygymapp.data.WorkoutStorage
+import com.example.mygymapp.model.WeekProgress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneId
+
+class HomeViewModel(application: Application) : AndroidViewModel(application) {
+    private val repo = PlanRepository(AppDatabase.getDatabase(application).planDao())
+    private val exerciseRepo = ExerciseRepository(AppDatabase.getDatabase(application).exerciseDao())
+    private val storage = WorkoutStorage(application)
+    private val historyStore = WorkoutHistoryStorage.getInstance(application)
+
+    private val _progress = MutableStateFlow<WeekProgress?>(null)
+    val progress: StateFlow<WeekProgress?> = _progress.asStateFlow()
+
+    private val _todayPlan = MutableStateFlow<PlanWithExercises?>(null)
+    val todayPlan: StateFlow<PlanWithExercises?> = _todayPlan.asStateFlow()
+
+    private val _history = MutableStateFlow(historyStore.loadAll())
+    val history: StateFlow<Map<LocalDate, WorkoutHistoryEntry>> = _history.asStateFlow()
+
+    private val _exercises = MutableStateFlow<List<Exercise>>(emptyList())
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            exerciseRepo.getAllExercises().collect { list ->
+                _exercises.value = list
+            }
+        }
+        loadProgress()
+    }
+
+    fun loadProgress() {
+        val state = storage.load()
+        _progress.value = state
+        state?.let { updateTodayPlan(it) } ?: _todayPlan.tryEmit(null)
+    }
+
+    fun refreshHistory() {
+        _history.value = historyStore.loadAll()
+    }
+
+    private fun updateTodayPlan(state: WeekProgress) {
+        val planId = if (state.day == 5 && state.modularPlanId != null && !state.modularRest) {
+            state.modularPlanId!!
+        } else {
+            state.weeklyPlanId
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            val plan = repo.getPlanWithExercisesOrNull(planId)
+            _todayPlan.emit(plan)
+        }
+    }
+
+    val lastWorkout: WorkoutHistoryEntry?
+        get() = history.value.maxByOrNull { it.key }?.value
+
+    val workoutsThisWeek: Int
+        get() {
+            val today = LocalDate.now(ZoneId.systemDefault())
+            val start = today.with(DayOfWeek.MONDAY)
+            return history.value.keys.count { !it.isBefore(start) }
+        }
+
+    val workoutStreak: Int
+        get() {
+            val today = LocalDate.now(ZoneId.systemDefault())
+            var day = today
+            var count = 0
+            while (history.value.containsKey(day)) {
+                count++
+                day = day.minusDays(1)
+            }
+            return count
+        }
+
+    fun getExerciseGroup(id: Long): String =
+        _exercises.value.firstOrNull { it.id == id }?.muscleGroup?.display ?: ""
+
+    suspend fun getEntryInfo(entry: WorkoutHistoryEntry): Pair<String, String>? = withContext(Dispatchers.IO) {
+        val plan = repo.getPlanWithExercisesOrNull(entry.planId) ?: return@withContext null
+        val planName = plan.plan.name
+        val dayName = plan.days.firstOrNull { it.dayIndex == entry.dayIndex }?.name
+            ?: "Day ${entry.dayIndex + 1}"
+        planName to dayName
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,16 @@
     <string name="goal_reps_label">Goal Reps</string>
     <string name="current_pr_label">Current PR: %1$d</string>
     <string name="goal_progress">%1$d%% of your goal reached</string>
+    <string name="home_today">Today: %1$s – %2$d exercises (ca. %3$d min)</string>
+    <string name="home_goal">Target: %1$s</string>
+    <string name="home_no_plan">No plan active – start now?</string>
+    <string name="home_start_workout">Start workout</string>
+    <string name="home_choose_plan">Choose plan</string>
+    <string name="home_last_active">Last active: %1$s, %2$s</string>
+    <string name="home_no_workout">No workout completed yet</string>
+    <string name="home_streak">🔥 %1$d day streak</string>
+    <string name="home_week_progress">%1$d / %2$d workouts completed</string>
+    <string name="home_view_progress">View progress</string>
     <string name="home">Home</string>
     <string name="exercises">Exercises</string>
     <string name="nav_start">Start</string>


### PR DESCRIPTION
## Summary
- add strings for Home screen content
- implement SectionHeader component
- create HomeViewModel for aggregated data
- implement HomeScreen with weekly overview
- start navigation at new `main` route

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e783f76a8832a9236bfe4825103eb