### PR TITLE
Improve bookmark-style menu animation

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/BookmarkMenu.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/BookmarkMenu.kt
@@ -1,0 +1,85 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BookmarkMenu(
+    isOpen: Boolean,
+    onDismiss: () -> Unit,
+    onItemSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    expandedHeight: Dp = 250.dp
+) {
+    val height by animateDpAsState(
+        targetValue = if (isOpen) expandedHeight else 0.dp,
+        animationSpec = spring(dampingRatio = 0.7f)
+    )
+
+    if (isOpen) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) { onDismiss() }
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .offset(x = 16.dp, y = 72.dp)
+            .width(220.dp)
+            .height(height)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color(0xFFF2EDE3))
+    ) {
+        if (height > 0.dp) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                listOf(
+                    "Today's Page",
+                    "Table of Contents",
+                    "Lines & Paragraphs",
+                    "Chronicle",
+                    "Impressum"
+                ).forEach { label ->
+                    Text(
+                        text = label,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp)
+                            .clickable {
+                                onItemSelected(label)
+                                onDismiss()
+                            },
+                        style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Serif)
+                    )
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/BookmarkToggleIcon.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/BookmarkToggleIcon.kt
@@ -1,0 +1,46 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BookmarkToggleIcon(
+    isOpen: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .statusBarsPadding()
+            .padding(start = 8.dp, top = 8.dp)
+            .width(40.dp)
+            .height(60.dp)
+            .clip(RoundedCornerShape(bottomEnd = 12.dp))
+            .background(Color(0xFF3F4E3A))
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = if (isOpen) Icons.Default.Close else Icons.Default.MenuBook,
+            contentDescription = "Bookmark Menu",
+            tint = Color.White
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
@@ -1,33 +1,21 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.MenuBook
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
+import com.example.mygymapp.ui.components.BookmarkMenu
+import com.example.mygymapp.ui.components.BookmarkToggleIcon
 
 @Composable
 fun PageScaffold() {
     var currentPage by remember { mutableStateOf("entry") }
-    var menuOpen by remember { mutableStateOf(false) }
+    var isMenuOpen by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         when (currentPage) {
@@ -38,50 +26,23 @@ fun PageScaffold() {
             "impressum" -> ImpressumPage()
         }
 
-        IconButton(
-            onClick = { menuOpen = true },
-            modifier = Modifier
-                .statusBarsPadding()
-                .padding(start = 16.dp, top = 8.dp)
-                .align(Alignment.TopStart)
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.MenuBook,
-                contentDescription = "Menü",
-                tint = MaterialTheme.colorScheme.onBackground
-            )
-        }
+        BookmarkToggleIcon(
+            isOpen = isMenuOpen,
+            onClick = { isMenuOpen = !isMenuOpen },
+            modifier = Modifier.align(Alignment.TopStart)
+        )
 
-        if (menuOpen) {
-            Card(
-                modifier = Modifier
-                    .padding(top = 72.dp, start = 24.dp)
-                    .align(Alignment.TopStart),
-                shape = RoundedCornerShape(16.dp),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text("\uD83D\uDCD6 Eintrag", modifier = Modifier.clickable {
-                        currentPage = "entry"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDCD8 Inhaltsverzeichnis", modifier = Modifier.clickable {
-                        currentPage = "toc"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDCC2 Archiv", modifier = Modifier.clickable {
-                        currentPage = "archive"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDDFA\uFE0F Chronik", modifier = Modifier.clickable {
-                        currentPage = "chronicle"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDCDD Impressum", modifier = Modifier.clickable {
-                        currentPage = "impressum"
-                        menuOpen = false
-                    })
-                }
+        BookmarkMenu(
+            isOpen = isMenuOpen,
+            onDismiss = { isMenuOpen = false },
+            modifier = Modifier.align(Alignment.TopStart)
+        ) { label ->
+            currentPage = when (label) {
+                "Today's Page" -> "entry"
+                "Table of Contents" -> "toc"
+                "Lines & Paragraphs" -> "archive"
+                "Chronicle" -> "chronicle"
+                else -> "impressum"
             }
         }
     }


### PR DESCRIPTION
## Summary
- refine the bookmark navigation menu
  - make toggle a forest-green ribbon in the corner
  - grow the menu downward with a spring height animation
  - close menu on outside tap
- adjust scaffold to use updated menu

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fa6bd3570832aa8eaf047e8fda9d6