### PR TITLE
Improve bookmark-style menu animation

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/BookmarkMenu.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/BookmarkMenu.kt
@@ -1,0 +1,71 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.ui.components.BookmarkToggleIcon
+
+@Composable
+fun BookmarkMenu(
+    isOpen: Boolean,
+    onToggle: () -> Unit,
+    onItemSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        BookmarkToggleIcon(
+            isOpen = isOpen,
+            onClick = onToggle
+        )
+
+        AnimatedVisibility(
+            visible = isOpen,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(220.dp)
+                    .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
+                    .background(Color(0xFFF2EDE3))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    listOf(
+                        "Today's Page",
+                        "Table of Contents",
+                        "Lines & Paragraphs",
+                        "Chronicle",
+                        "Impressum"
+                    ).forEach { label ->
+                        Text(
+                            text = label,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                                .clickable {
+                                    onItemSelected(label)
+                                },
+                            style = MaterialTheme.typography.bodyLarge.copy(fontFamily = FontFamily.Serif)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/BookmarkToggleIcon.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/BookmarkToggleIcon.kt
@@ -1,0 +1,43 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BookmarkToggleIcon(
+    isOpen: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .width(48.dp)
+            .height(56.dp)
+            .clip(RoundedCornerShape(bottomEnd = 12.dp))
+            .background(Color(0xFF3F4E3A))
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = if (isOpen) Icons.Default.Close else Icons.Default.MenuBook,
+            contentDescription = "Bookmark Menu",
+            tint = Color.White,
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
@@ -1,33 +1,24 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.MenuBook
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.unit.dp
+import com.example.mygymapp.ui.components.BookmarkMenu
 
 @Composable
 fun PageScaffold() {
     var currentPage by remember { mutableStateOf("entry") }
-    var menuOpen by remember { mutableStateOf(false) }
+    var isMenuOpen by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         when (currentPage) {
@@ -38,51 +29,33 @@ fun PageScaffold() {
             "impressum" -> ImpressumPage()
         }
 
-        IconButton(
-            onClick = { menuOpen = true },
-            modifier = Modifier
-                .statusBarsPadding()
-                .padding(start = 16.dp, top = 8.dp)
-                .align(Alignment.TopStart)
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.MenuBook,
-                contentDescription = "Menü",
-                tint = MaterialTheme.colorScheme.onBackground
+        if (isMenuOpen) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) { isMenuOpen = false }
             )
         }
 
-        if (menuOpen) {
-            Card(
-                modifier = Modifier
-                    .padding(top = 72.dp, start = 24.dp)
-                    .align(Alignment.TopStart),
-                shape = RoundedCornerShape(16.dp),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text("\uD83D\uDCD6 Eintrag", modifier = Modifier.clickable {
-                        currentPage = "entry"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDCD8 Inhaltsverzeichnis", modifier = Modifier.clickable {
-                        currentPage = "toc"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDCC2 Archiv", modifier = Modifier.clickable {
-                        currentPage = "archive"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDDFA\uFE0F Chronik", modifier = Modifier.clickable {
-                        currentPage = "chronicle"
-                        menuOpen = false
-                    })
-                    Text("\uD83D\uDCDD Impressum", modifier = Modifier.clickable {
-                        currentPage = "impressum"
-                        menuOpen = false
-                    })
+        BookmarkMenu(
+            isOpen = isMenuOpen,
+            onToggle = { isMenuOpen = !isMenuOpen },
+            onItemSelected = { label ->
+                currentPage = when (label) {
+                    "Today's Page" -> "entry"
+                    "Table of Contents" -> "toc"
+                    "Lines & Paragraphs" -> "archive"
+                    "Chronicle" -> "chronicle"
+                    else -> "impressum"
                 }
-            }
-        }
+                isMenuOpen = false
+            },
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(start = 8.dp, top = 0.dp)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- refactor BookmarkMenu so toggle and menu share one column
- animate menu with expand/shrink to push the bookmark downward
- keep the bookmark flush with the screen top

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fa6bd3570832aa8eaf047e8fda9d6