### PR TITLE
Enhance bookmark navigation

### DIFF
--- a/app/src/main/java/com/example/mygymapp/MainActivity.kt
+++ b/app/src/main/java/com/example/mygymapp/MainActivity.kt
@@ -3,12 +3,14 @@ package com.example.mygymapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import com.example.mygymapp.ui.theme.MyGymAppTheme
 import com.example.mygymapp.ui.pages.PageScaffold
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             MyGymAppTheme {
                 PageScaffold()

--- a/app/src/main/java/com/example/mygymapp/ui/components/BookmarkMenu.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/BookmarkMenu.kt
@@ -1,10 +1,10 @@
 package com.example.mygymapp.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -20,12 +20,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.zIndex
 import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.asPaddingValues
 @Composable
 fun BookmarkMenu(
     isOpen: Boolean,
@@ -33,21 +30,21 @@ fun BookmarkMenu(
     onItemSelected: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    Box(
         modifier = modifier
-            .statusBarsPadding()
+            .padding(start = 12.dp, top = 12.dp)
             .zIndex(2f)
     ) {
         BookmarkToggleIcon(
             isOpen = isOpen,
             onClick = onToggle,
-            modifier = Modifier.offset(y = (-16).dp)
+            modifier = Modifier.offset(y = (-24).dp)
         )
 
         AnimatedVisibility(
             visible = isOpen,
-            enter = expandVertically() + fadeIn(),
-            exit = shrinkVertically() + fadeOut()
+            enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+            exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/example/mygymapp/ui/components/BookmarkToggleIcon.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/BookmarkToggleIcon.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -12,9 +11,12 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
@@ -26,17 +28,19 @@ fun BookmarkToggleIcon(
 ) {
     Box(
         modifier = modifier
-            .width(48.dp)
-            .height(72.dp)
-            .clip(RoundedCornerShape(bottomEnd = 12.dp))
+            .width(56.dp)
+            .height(96.dp)
+            .clip(RoundedCornerShape(bottomEnd = 20.dp))
             .background(Color(0xFF3F4E3A))
             .clickable { onClick() },
         contentAlignment = Alignment.BottomCenter
     ) {
+        val rotation by animateFloatAsState(if (isOpen) 90f else 0f)
         Icon(
             imageVector = if (isOpen) Icons.Default.Close else Icons.Default.MenuBook,
             contentDescription = "Bookmark Menu",
             tint = Color.White,
+            modifier = Modifier.rotate(rotation)
         )
     }
 }


### PR DESCRIPTION
## Summary
- draw behind system bars and position navigation like a physical bookmark
- enlarge and animate the bookmark toggle icon
- slide the menu down from the bookmark

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff7136070832aaa5591b6dc6574fb