### PR TITLE
Improve journaling entry page

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/EntryHeader.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/EntryHeader.kt
@@ -38,14 +38,18 @@ fun EntryHeader(
             text = "ENTRY ${'$'}entryNumber",
             style = MaterialTheme.typography.headlineSmall.copy(
                 fontFamily = FontFamily.Serif,
-                fontSize = 28.sp
+                fontSize = 28.sp,
+                color = Color.Black
             ),
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(4.dp))
         Text(
             text = date.format(formatter),
-            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Serif),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.Serif,
+                color = Color.DarkGray
+            ),
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(12.dp))

--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
@@ -2,13 +2,17 @@
 package com.example.mygymapp.ui.pages
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -22,15 +26,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mygymapp.ui.theme.handwritingText
-import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.components.EntryHeader
+import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.theme.handwritingText
+import androidx.compose.ui.draw.clip
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 
 
@@ -38,8 +42,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 @Composable
 fun EntryPage() {
     val today = LocalDate.now()
-    val entryNumber = 446
-    val formatter = DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.ENGLISH)
+    var entryNumber by remember { mutableStateOf(1) }
 
     var mood by remember { mutableStateOf<String?>(null) }
     val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
@@ -50,6 +53,7 @@ fun EntryPage() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp, vertical = 32.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -59,22 +63,49 @@ fun EntryPage() {
             date = today
         )
 
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        val emotionColors = listOf(
+            Color(0xFFFFCDD2),
+            Color(0xFFBBDEFB),
+            Color(0xFFC8E6C9),
+            Color(0xFFFFF9C4),
+            Color(0xFFD7CCC8),
+            Color(0xFFD1C4E9),
+            Color(0xFFFFE0B2)
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
-            moods.forEach { option ->
-                AssistChip(
-                    onClick = { mood = option },
-                    label = { Text(option) },
-                )
+            moods.forEachIndexed { index, option ->
+                val selected = mood == option
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(emotionColors[index % emotionColors.size])
+                        .border(
+                            width = if (selected) 3.dp else 1.dp,
+                            color = if (selected) Color.Black else Color.DarkGray,
+                            shape = CircleShape
+                        )
+                        .clickable { mood = option },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = option.take(1).uppercase(),
+                        color = Color.Black,
+                        fontFamily = FontFamily.Serif,
+                        fontSize = 14.sp
+                    )
+                }
             }
         }
 
         Text(
             text = "Today: Push · 3 movements · 34 minutes",
-            style = MaterialTheme.typography.bodyMedium.copy(color = Color.Gray),
+            style = MaterialTheme.typography.bodyMedium.copy(color = Color.DarkGray),
             textAlign = TextAlign.Center
         )
 
@@ -91,10 +122,15 @@ fun EntryPage() {
         )
 
         Button(
-            onClick = { isFinished = true },
+            onClick = {
+                entryNumber += 1
+                mood = null
+                story = ""
+                isFinished = true
+            },
             shape = RoundedCornerShape(12.dp)
         ) {
-            Text("Finish this page")
+            Text("Finish this page", color = Color.Black)
         }
 
         if (isFinished) {


### PR DESCRIPTION
## Summary
- adjust EntryHeader colors
- redesign EntryPage emotion selector as circular buttons
- increment entry count with Finish button
- darken text colors and pad for status bar

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826bbe39ec832aaf6524c03af91d58