### PR TITLE
Add persistent entry counter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.5.1")
     implementation("io.coil-kt:coil-compose:2.5.0")
     implementation("org.burnoutcrew.composereorderable:reorderable:0.9.6")
+    implementation("androidx.datastore:datastore-preferences:1.1.0")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
     // DEBUG/DEV
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/java/com/example/mygymapp/data/EntryNumberStore.kt
+++ b/app/src/main/java/com/example/mygymapp/data/EntryNumberStore.kt
@@ -1,0 +1,51 @@
+package com.example.mygymapp.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.first
+import java.time.LocalDate
+
+private val Context.entryDataStore by preferencesDataStore("journal_entries")
+
+class EntryNumberStore private constructor(private val context: Context) {
+    private val dataStore = context.entryDataStore
+    private val ENTRY_KEY = intPreferencesKey("entry_number")
+    private val DAY_KEY = longPreferencesKey("last_increment_day")
+
+    val entryNumberFlow: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[ENTRY_KEY] ?: 1
+    }
+
+    suspend fun loadCurrent(): Int {
+        val prefs = dataStore.data.first()
+        val storedNum = prefs[ENTRY_KEY] ?: 1
+        val storedDay = prefs[DAY_KEY] ?: LocalDate.now().toEpochDay()
+        val today = LocalDate.now().toEpochDay()
+        return if (today > storedDay) {
+            val next = storedNum + 1
+            dataStore.edit {
+                it[ENTRY_KEY] = next
+                it[DAY_KEY] = today
+            }
+            next
+        } else {
+            storedNum
+        }
+    }
+
+    companion object {
+        @Volatile
+        private var INSTANCE: EntryNumberStore? = null
+
+        fun getInstance(context: Context): EntryNumberStore {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: EntryNumberStore(context.applicationContext).also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/components/EntryHeader.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/EntryHeader.kt
@@ -35,17 +35,21 @@ fun EntryHeader(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "ENTRY ${'$'}entryNumber",
+            text = "ENTRY $entryNumber",
             style = MaterialTheme.typography.headlineSmall.copy(
                 fontFamily = FontFamily.Serif,
-                fontSize = 28.sp
+                fontSize = 28.sp,
+                color = Color.Black
             ),
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(4.dp))
         Text(
             text = date.format(formatter),
-            style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Serif),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.Serif,
+                color = Color.DarkGray
+            ),
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(12.dp))

--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryNavigation.kt
@@ -1,0 +1,80 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.mygymapp.viewmodel.EntryViewModel
+
+@Composable
+fun EntryNavigation(modifier: Modifier = Modifier) {
+    val navController = rememberNavController()
+    val vm: EntryViewModel = viewModel()
+    val entryNumber by vm.entryNumber.collectAsState()
+
+    NavHost(
+        navController = navController,
+        startDestination = "entry",
+        modifier = modifier
+    ) {
+        composable("entry") {
+            androidx.compose.runtime.LaunchedEffect(Unit) {
+                vm.refresh()
+            }
+            EntryPage(
+                entryNumber = entryNumber,
+                onFinished = {
+                    navController.navigate("done")
+                }
+            )
+        }
+        composable("done") {
+            ConfirmationPage(onBack = { navController.popBackStack() })
+        }
+    }
+}
+
+@Composable
+fun ConfirmationPage(onBack: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(24.dp)
+    ) {
+        Text(
+            text = "A new page was written.",
+            modifier = Modifier.align(Alignment.Center),
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontFamily = FontFamily.Serif,
+                color = Color.Black
+            )
+        )
+        TextButton(
+            onClick = onBack,
+            modifier = Modifier.align(Alignment.BottomStart)
+        ) {
+            Text(
+                text = "Back",
+                color = Color.Black,
+                fontFamily = FontFamily.Serif
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
@@ -2,13 +2,17 @@
 package com.example.mygymapp.ui.pages
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -21,35 +25,35 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mygymapp.ui.theme.handwritingText
-import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.components.EntryHeader
+import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.theme.handwritingText
+import androidx.compose.ui.draw.clip
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun EntryPage() {
+fun EntryPage(
+    entryNumber: Int,
+    onFinished: () -> Unit
+) {
     val today = LocalDate.now()
-    val entryNumber = 446
-    val formatter = DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.ENGLISH)
 
     var mood by remember { mutableStateOf<String?>(null) }
     val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
     var story by remember { mutableStateOf("") }
-    var isFinished by remember { mutableStateOf(false) }
 
     PaperBackground {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 24.dp, vertical = 32.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -59,22 +63,49 @@ fun EntryPage() {
             date = today
         )
 
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        val emotionColors = listOf(
+            Color(0xFFFFCDD2),
+            Color(0xFFBBDEFB),
+            Color(0xFFC8E6C9),
+            Color(0xFFFFF9C4),
+            Color(0xFFD7CCC8),
+            Color(0xFFD1C4E9),
+            Color(0xFFFFE0B2)
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
-            moods.forEach { option ->
-                AssistChip(
-                    onClick = { mood = option },
-                    label = { Text(option) },
-                )
+            moods.forEachIndexed { index, option ->
+                val selected = mood == option
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(emotionColors[index % emotionColors.size])
+                        .border(
+                            width = if (selected) 3.dp else 1.dp,
+                            color = if (selected) Color.Black else Color.DarkGray,
+                            shape = CircleShape
+                        )
+                        .clickable { mood = option },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = option.take(1).uppercase(),
+                        color = Color.Black,
+                        fontFamily = FontFamily.Serif,
+                        fontSize = 14.sp
+                    )
+                }
             }
         }
 
         Text(
             text = "Today: Push · 3 movements · 34 minutes",
-            style = MaterialTheme.typography.bodyMedium.copy(color = Color.Gray),
+            style = MaterialTheme.typography.bodyMedium.copy(color = Color.DarkGray),
             textAlign = TextAlign.Center
         )
 
@@ -91,18 +122,14 @@ fun EntryPage() {
         )
 
         Button(
-            onClick = { isFinished = true },
+            onClick = {
+                mood = null
+                story = ""
+                onFinished()
+            },
             shape = RoundedCornerShape(12.dp)
         ) {
-            Text("Finish this page")
-        }
-
-        if (isFinished) {
-            Text(
-                text = "A new page was written.",
-                style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic),
-                modifier = Modifier.padding(top = 16.dp)
-            )
+            Text("Finish this page", color = Color.Black)
         }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
@@ -21,7 +21,7 @@ fun PageScaffold() {
 
     Box(modifier = Modifier.fillMaxSize()) {
         when (currentPage) {
-            "entry" -> EntryPage()
+            "entry" -> EntryNavigation()
             "toc" -> TocPage()
             "archive" -> ArchivePage()
             "chronicle" -> ChroniclePage()

--- a/app/src/main/java/com/example/mygymapp/viewmodel/EntryViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/EntryViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.mygymapp.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mygymapp.data.EntryNumberStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class EntryViewModel(application: Application) : AndroidViewModel(application) {
+    private val store = EntryNumberStore.getInstance(application)
+
+    private val _entryNumber = MutableStateFlow(1)
+    val entryNumber: StateFlow<Int> = _entryNumber.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _entryNumber.value = store.loadCurrent()
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _entryNumber.value = store.loadCurrent()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- include DataStore for storing the journal entry counter
- create `EntryNumberStore` to persist and load the count
- add `EntryViewModel` to manage the entry number
- update `EntryNavigation` to use the ViewModel
- adjust logic so the entry number increments once per day at midnight

## Testing
- `./gradlew assembleDebug --stacktrace --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826bbe39ec832aaf6524c03af91d58