### PR TITLE
Improve back button placement and visibility

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryNavigation.kt
@@ -2,6 +2,7 @@ package com.example.mygymapp.ui.pages
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +15,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
@@ -68,11 +73,17 @@ fun ConfirmationPage(onBack: () -> Unit) {
         )
         TextButton(
             onClick = onBack,
-            modifier = Modifier.align(Alignment.BottomStart)
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .navigationBarsPadding()
+                .padding(bottom = 24.dp)
+                .shadow(4.dp, RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(8.dp))
+                .background(Color.Black.copy(alpha = 0.6f))
         ) {
             Text(
                 text = "Back",
-                color = Color.Black,
+                color = Color.White,
                 fontFamily = FontFamily.Serif
             )
         }


### PR DESCRIPTION
## Summary
- keep the ConfirmationPage back button clear of the system navigation bar
- give the button a subtle background and shadow so it stands out on dark images

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68829686e604832a88a8edc0c28565dd