### PR TITLE
Add LineArchivePage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Line.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Line.kt
@@ -1,0 +1,18 @@
+package com.example.mygymapp.model
+
+import com.example.mygymapp.model.ExerciseEntry
+
+/**
+ * Represents a single daily workout "Line" in the training diary.
+ */
+data class Line(
+    val id: Long,
+    val title: String,
+    val category: String,
+    val muscleGroup: String,
+    val mood: String,
+    val exercises: List<ExerciseEntry>,
+    val supersets: List<Pair<Long, Long>>, // pair of exercise ids forming a superset
+    val note: String,
+    val isArchived: Boolean = false
+)

--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -1,0 +1,69 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.animation.core.animateFloatAsState
+import com.example.mygymapp.model.Line
+
+@Composable
+fun LineCard(
+    line: Line,
+    onEdit: () -> Unit,
+    onAdd: () -> Unit,
+    onArchive: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val fade by animateFloatAsState(if (line.isArchived) 0f else 1f, label = "fade")
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .alpha(fade),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = line.title,
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${line.category} · ${line.muscleGroup} · ${line.mood}",
+                style = MaterialTheme.typography.bodySmall
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
+                style = MaterialTheme.typography.bodySmall
+            )
+            if (line.note.isNotBlank()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "📎 ${line.note}",
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextButton(onClick = onEdit) { Text("✏️ Edit") }
+                TextButton(onClick = onAdd) { Text("📥 Add") }
+                TextButton(onClick = onArchive) { Text("📦 Archive") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchivePage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchivePage.kt
@@ -1,16 +1,69 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.remember
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.ExerciseEntry
+import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.model.MuscleGroup
+
 
 @Composable
 fun ArchivePage() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Archiv", style = MaterialTheme.typography.headlineSmall)
+    val demoLines = remember {
+        listOf(
+            Line(
+                id = 1,
+                title = "Silent Force",
+                category = "Push",
+                muscleGroup = "Core",
+                mood = "balanced",
+                exercises = listOf(
+                    ExerciseEntry(
+                        exercise = Exercise(
+                            id = 0,
+                            name = "Push-up",
+                            description = "",
+                            category = ExerciseCategory.Calisthenics,
+                            likeability = 5,
+                            muscleGroup = MuscleGroup.Chest,
+                            muscle = "Pectorals"
+                        )
+                    )
+                ),
+                supersets = emptyList(),
+                note = "Felt steady and grounded throughout."
+            ),
+            Line(
+                id = 2,
+                title = "Night Owl Session",
+                category = "Pull",
+                muscleGroup = "Back",
+                mood = "alert",
+                exercises = listOf(
+                    ExerciseEntry(
+                        exercise = Exercise(
+                            id = 1,
+                            name = "Pull-up",
+                            description = "",
+                            category = ExerciseCategory.Calisthenics,
+                            likeability = 5,
+                            muscleGroup = MuscleGroup.Back,
+                            muscle = "Latissimus"
+                        )
+                    )
+                ),
+                supersets = listOf(1L to 2L),
+                note = "Late session with high focus."
+            )
+        )
     }
+
+    LineArchivePage(
+        lines = demoLines,
+        onEdit = {},
+        onAdd = {},
+        onArchive = {}
+    )
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineArchivePage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineArchivePage.kt
@@ -1,0 +1,41 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.components.LineCard
+import com.example.mygymapp.ui.components.PaperBackground
+
+@Composable
+fun LineArchivePage(
+    lines: List<Line>,
+    onEdit: (Line) -> Unit,
+    onAdd: (Line) -> Unit,
+    onArchive: (Line) -> Unit
+) {
+
+    PaperBackground(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(lines) { line ->
+                LineCard(
+                    line = line,
+                    onEdit = { onEdit(line) },
+                    onAdd = { onAdd(line) },
+                    onArchive = { onArchive(line) },
+                    modifier = Modifier.padding(horizontal = 24.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `Line` data model
- implement `LineCard` composable to display diary lines
- create `LineArchivePage` for viewing archived lines
- hook existing `ArchivePage` to use new archive page
- fix demo Exercise initialization

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688367a5a674832aa20160b245dd6811