### PR TITLE
Add LineArchivePage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Line.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Line.kt
@@ -1,0 +1,18 @@
+package com.example.mygymapp.model
+
+import com.example.mygymapp.model.ExerciseEntry
+
+/**
+ * Represents a single daily workout "Line" in the training diary.
+ */
+data class Line(
+    val id: Long,
+    val title: String,
+    val category: String,
+    val muscleGroup: String,
+    val mood: String,
+    val exercises: List<ExerciseEntry>,
+    val supersets: List<Pair<Long, Long>>, // pair of exercise ids forming a superset
+    val note: String,
+    val isArchived: Boolean = false
+)

--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -1,0 +1,69 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.animation.core.animateFloatAsState
+import com.example.mygymapp.model.Line
+
+@Composable
+fun LineCard(
+    line: Line,
+    onEdit: () -> Unit,
+    onAdd: () -> Unit,
+    onArchive: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val fade by animateFloatAsState(if (line.isArchived) 0f else 1f, label = "fade")
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .alpha(fade),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = line.title,
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${line.category} · ${line.muscleGroup} · ${line.mood}",
+                style = MaterialTheme.typography.bodySmall
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
+                style = MaterialTheme.typography.bodySmall
+            )
+            if (line.note.isNotBlank()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "📎 ${line.note}",
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextButton(onClick = onEdit) { Text("✏️ Edit") }
+                TextButton(onClick = onAdd) { Text("📥 Add") }
+                TextButton(onClick = onArchive) { Text("📦 Archive") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
@@ -1,0 +1,19 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun ArchiveNavigation() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = "lines") {
+        composable("lines") {
+            ArchivePage(onManageExercises = { navController.navigate("exercise_management") })
+        }
+        composable("exercise_management") {
+            ExerciseManagementScreen(navController = navController)
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchivePage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchivePage.kt
@@ -1,16 +1,82 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.remember
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.ExerciseEntry
+import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.model.MuscleGroup
+
 
 @Composable
-fun ArchivePage() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("Archiv", style = MaterialTheme.typography.headlineSmall)
+fun ArchivePage(onManageExercises: () -> Unit) {
+    val demoLines = remember {
+        listOf(
+            Line(
+                id = 1,
+                title = "Silent Force",
+                category = "Push",
+                muscleGroup = "Core",
+                mood = "balanced",
+                exercises = listOf(
+                    ExerciseEntry(
+                        exercise = Exercise(
+                            id = 0,
+                            name = "Push-up",
+                            description = "",
+                            category = ExerciseCategory.Calisthenics,
+                            likeability = 5,
+                            muscleGroup = MuscleGroup.Chest,
+                            muscle = "Pectorals"
+                        )
+                    )
+                ),
+                supersets = emptyList(),
+                note = "Felt steady and grounded throughout."
+            ),
+            Line(
+                id = 2,
+                title = "Night Owl Session",
+                category = "Pull",
+                muscleGroup = "Back",
+                mood = "alert",
+                exercises = listOf(
+                    ExerciseEntry(
+                        exercise = Exercise(
+                            id = 1,
+                            name = "Pull-up",
+                            description = "",
+                            category = ExerciseCategory.Calisthenics,
+                            likeability = 5,
+                            muscleGroup = MuscleGroup.Back,
+                            muscle = "Latissimus"
+                        )
+                    )
+                ),
+                supersets = listOf(1L to 2L),
+                note = "Late session with high focus."
+            )
+        )
+    }
+
+    LineArchivePage(
+        lines = demoLines,
+        onEdit = {},
+        onAdd = {},
+        onArchive = {}
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+    TextButton(onClick = onManageExercises, modifier = Modifier.padding(horizontal = 24.dp)) {
+        Text("✍️ Edit Exercises", fontFamily = FontFamily.Serif)
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ExerciseManagementScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ExerciseManagementScreen.kt
@@ -1,0 +1,112 @@
+package com.example.mygymapp.ui.pages
+
+import android.net.Uri
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.mygymapp.data.Exercise
+import com.example.mygymapp.model.ExerciseCategory
+import com.example.mygymapp.model.MuscleGroup
+import com.example.mygymapp.ui.components.AddEditExerciseSheet
+import com.example.mygymapp.ui.components.ExerciseCard
+import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.viewmodel.ExerciseViewModel
+
+@Composable
+fun ExerciseManagementScreen(navController: NavController) {
+    val vm: ExerciseViewModel = viewModel()
+    val exercises by vm.allExercises.observeAsState(emptyList())
+
+    var editing by remember { mutableStateOf<Exercise?>(null) }
+    var showSheet by remember { mutableStateOf(false) }
+
+    val categories = ExerciseCategory.values().map { it.display }
+    val muscles = MuscleGroup.values().map { it.display }
+
+    PaperBackground(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Exercise Library",
+                    style = MaterialTheme.typography.headlineSmall.copy(fontFamily = FontFamily.Serif)
+                )
+                TextButton(onClick = { editing = null; showSheet = true }) {
+                    Text("Add", fontFamily = FontFamily.Serif)
+                }
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(exercises) { ex ->
+                    ExerciseCard(
+                        ex = ex,
+                        onClick = {
+                            editing = ex
+                            showSheet = true
+                        },
+                        onToggleFavorite = { vm.toggleFavorite(ex) }
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = {
+                            editing = ex
+                            showSheet = true
+                        }) { Text("Edit", fontFamily = FontFamily.Serif) }
+                        TextButton(onClick = { vm.delete(ex.id) }) {
+                            Text("Delete", fontFamily = FontFamily.Serif)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showSheet) {
+        AddEditExerciseSheet(
+            initialName = editing?.name ?: "",
+            initialCategory = editing?.category?.display ?: "",
+            initialMuscleGroup = editing?.muscleGroup?.display ?: "",
+            initialRating = editing?.likeability ?: 3,
+            initialImageUri = editing?.imageUri?.let { Uri.parse(it) },
+            onSave = { name, cat, group, rating, uri ->
+                val category = ExerciseCategory.values().find { it.display == cat } ?: ExerciseCategory.Calisthenics
+                val muscleGroup = MuscleGroup.values().find { it.display == group } ?: MuscleGroup.Core
+                val exercise = Exercise(
+                    id = editing?.id ?: 0,
+                    name = name,
+                    description = "",
+                    category = category,
+                    likeability = rating,
+                    muscleGroup = muscleGroup,
+                    muscle = muscleGroup.display,
+                    imageUri = uri?.toString(),
+                    isFavorite = editing?.isFavorite ?: false
+                )
+                if (editing == null) vm.insert(exercise) else vm.update(exercise)
+                showSheet = false
+            },
+            onCancel = { showSheet = false },
+            categories = categories,
+            muscleGroups = muscles
+        )
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineArchivePage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineArchivePage.kt
@@ -1,0 +1,41 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.components.LineCard
+import com.example.mygymapp.ui.components.PaperBackground
+
+@Composable
+fun LineArchivePage(
+    lines: List<Line>,
+    onEdit: (Line) -> Unit,
+    onAdd: (Line) -> Unit,
+    onArchive: (Line) -> Unit
+) {
+
+    PaperBackground(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(lines) { line ->
+                LineCard(
+                    line = line,
+                    onEdit = { onEdit(line) },
+                    onAdd = { onAdd(line) },
+                    onArchive = { onArchive(line) },
+                    modifier = Modifier.padding(horizontal = 24.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
@@ -23,7 +23,7 @@ fun PageScaffold() {
         when (currentPage) {
             "entry" -> EntryNavigation()
             "toc" -> TocPage()
-            "archive" -> ArchivePage()
+            "archive" -> ArchiveNavigation()
             "chronicle" -> ChroniclePage()
             "impressum" -> ImpressumPage()
         }


### PR DESCRIPTION
## Summary
- create `Line` data model
- implement `LineCard` composable to display diary lines
- create `LineArchivePage` for viewing archived lines
- hook existing `ArchivePage` to use new archive page
- fix demo Exercise initialization
- add Exercise Management navigation with new `ArchiveNavigation`
- add `ExerciseManagementScreen`

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688367a5a674832aa20160b245dd6811