### PR TITLE
Fix deprecations and navigation callback

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.fillMaxSize
 
 @Composable
-fun ArchiveNavigation() {
+fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
     val navController = rememberNavController()
     NavHost(navController = navController, startDestination = "lines") {
         composable("lines") {
@@ -75,7 +75,8 @@ fun ArchiveNavigation() {
                     },
                     onCancel = {
                         navController.popBackStack()
-                    }
+                    },
+                    onNavigateToEntry = onNavigateToEntry
                 )
             }
         }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ExerciseEditorScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ExerciseEditorScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.Photo
 import androidx.compose.material3.*
@@ -102,7 +102,10 @@ fun ExerciseEditorScreen(
                     },
                     navigationIcon = {
                         IconButton(onClick = onCancel) {
-                            Icon(Icons.Default.ArrowBack, contentDescription = "Cancel")
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Cancel"
+                            )
                         }
                     }
                 )
@@ -236,11 +239,12 @@ fun StyledTextField(
             .fillMaxWidth()
             .height(height),
         textStyle = if (isHandwriting) handwritingText else TextStyle(fontFamily = FontFamily.Serif, color = MaterialTheme.colorScheme.onSurface),
-        colors = TextFieldDefaults.outlinedTextFieldColors(
+        colors = OutlinedTextFieldDefaults.colors(
             focusedBorderColor = MaterialTheme.colorScheme.primary,
             unfocusedBorderColor = MaterialTheme.colorScheme.outline,
             cursorColor = MaterialTheme.colorScheme.primary,
-            containerColor = Color.Transparent
+            focusedContainerColor = Color.Transparent,
+            unfocusedContainerColor = Color.Transparent
         )
     )
 }
@@ -260,8 +264,9 @@ fun DropdownField(label: String, options: List<String>, selected: String, onSele
             label = { Text(label, fontFamily = FontFamily.Serif) },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             modifier = Modifier.menuAnchor().fillMaxWidth(),
-            colors = TextFieldDefaults.outlinedTextFieldColors(
-                containerColor = Color.Transparent
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent
             )
         )
         ExposedDropdownMenu(

--- a/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/PageScaffold.kt
@@ -23,7 +23,7 @@ fun PageScaffold() {
         when (currentPage) {
             "entry" -> EntryNavigation()
             "toc" -> TocPage()
-            "archive" -> ArchiveNavigation()
+            "archive" -> ArchiveNavigation(onNavigateToEntry = { currentPage = "entry" })
             "chronicle" -> ChroniclePage()
             "impressum" -> ImpressumPage()
         }


### PR DESCRIPTION
## Summary
- use the new AutoMirrored arrow back icon
- migrate to `OutlinedTextFieldDefaults.colors`
- forward navigation callback from ArchiveNavigation

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_6884fcb38a48832ab0ad79a1234758c4