### PR TITLE
Add edit mode to MovementEntryPage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
@@ -1,26 +1,15 @@
 package com.example.mygymapp.ui.pages
 
-import android.net.Uri
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
-import com.example.mygymapp.data.Exercise
-import com.example.mygymapp.model.ExerciseCategory
-import com.example.mygymapp.model.MuscleGroup
-import com.example.mygymapp.viewmodel.ExerciseViewModel
 
 @Composable
 fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
     val navController = rememberNavController()
-    val exerciseViewModel: ExerciseViewModel = viewModel()
 
     NavHost(navController = navController, startDestination = "lines") {
         composable("lines") {
@@ -36,71 +25,11 @@ fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
                 defaultValue = -1L
             })
         ) { backStackEntry ->
-            val editId = backStackEntry.arguments?.getLong("editId") ?: -1L
-            val exercisesState = exerciseViewModel.allExercises.observeAsState()
-            val editingExercise = exercisesState.value?.find { it.id == editId }
-
-            if (editId != -1L && editingExercise == null) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                }
-            } else {
-                MovementEntryPage(
-                    onSave = { name: String, category: String, muscleGroup: String, rating: Int, uri: Uri?, note: String ->
-                        val categoryEnum = ExerciseCategory.values().find { it.display == category } ?: ExerciseCategory.Calisthenics
-                        val muscleGroupEnum = MuscleGroup.values().find { it.display == muscleGroup } ?: MuscleGroup.Core
-
-                        val updatedExercise = Exercise(
-                            id = editingExercise?.id ?: 0,
-                            name = name,
-                            description = note,
-                            category = categoryEnum,
-                            likeability = rating,
-                            muscleGroup = muscleGroupEnum,
-                            muscle = muscleGroupEnum.display,
-                            imageUri = uri?.toString(),
-                            isFavorite = editingExercise?.isFavorite ?: false
-                        )
-
-                        if (editingExercise != null) {
-                            exerciseViewModel.update(updatedExercise)
-                        } else {
-                            exerciseViewModel.insert(updatedExercise)
-                        }
-
-                        navController.popBackStack()
-                    },
-                    onCancel = {
-                        navController.popBackStack()
-                    }
-                )
-            }
+            val editIdArg = backStackEntry.arguments?.getLong("editId")?.takeIf { it != -1L }
+            MovementEntryPage(navController = navController, editId = editIdArg)
         }
         composable("movement_editor") {
-            MovementEntryPage(
-                onSave = { name: String, category: String, muscleGroup: String, rating: Int, uri: Uri?, note: String ->
-                    val categoryEnum = ExerciseCategory.values().find { it.display == category } ?: ExerciseCategory.Calisthenics
-                    val muscleGroupEnum = MuscleGroup.values().find { it.display == muscleGroup } ?: MuscleGroup.Core
-
-                    val newExercise = Exercise(
-                        id = 0,
-                        name = name,
-                        description = note,
-                        category = categoryEnum,
-                        likeability = rating,
-                        muscleGroup = muscleGroupEnum,
-                        muscle = muscleGroupEnum.display,
-                        imageUri = uri?.toString(),
-                        isFavorite = false
-                    )
-
-                    exerciseViewModel.insert(newExercise)
-                    navController.popBackStack()
-                },
-                onCancel = {
-                    navController.popBackStack()
-                }
-            )
+            MovementEntryPage(navController = navController)
         }
     }
 }


### PR DESCRIPTION
## Summary
- make `MovementEntryPage` able to load and update exercises
- simplify navigation to pass the optional `editId`

## Testing
- `./gradlew help --console=plain --quiet`
- `./gradlew test --console=plain --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea992f08832a9213dc4752938a71