### PR TITLE
Add edit mode to MovementEntryPage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseHighlightCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseHighlightCard.kt
@@ -2,24 +2,30 @@ package com.example.mygymapp.ui.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.StarBorder
-import androidx.compose.material3.*
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.example.mygymapp.data.Exercise
 import androidx.compose.ui.draw.clip
+import androidx.compose.material3.MaterialTheme
+import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.pages.GaeguRegular
 
 @Composable
 fun ExerciseCardWithHighlight(
@@ -29,13 +35,12 @@ fun ExerciseCardWithHighlight(
     onDelete: () -> Unit,
     onToggleFavorite: (() -> Unit)? = null
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
-        elevation = CardDefaults.cardElevation(4.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
-        )
+    val cardColor = Color.White.copy(alpha = 0.8f)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(cardColor)
     ) {
         Row(modifier = Modifier.padding(16.dp)) {
 
@@ -53,16 +58,14 @@ fun ExerciseCardWithHighlight(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = highlightQuery(ex.name, query),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontFamily = FontFamily.Serif,
+                    style = MaterialTheme.typography.titleMedium.copy(fontFamily = GaeguBold),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
 
                 Text(
                     text = "${ex.muscleGroup.display} · ${ex.category.display}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontFamily = FontFamily.Serif,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontFamily = GaeguRegular),
                     color = Color.DarkGray
                 )
 
@@ -70,8 +73,7 @@ fun ExerciseCardWithHighlight(
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text = ex.description,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Serif,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = GaeguRegular),
                         color = Color.Gray,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis
@@ -94,10 +96,10 @@ fun ExerciseCardWithHighlight(
                         }
                     }
                     TextButton(onClick = onEdit) {
-                        Text("Edit", fontFamily = FontFamily.Serif)
+                        Text("Edit", fontFamily = GaeguRegular)
                     }
                     TextButton(onClick = onDelete) {
-                        Text("Delete", fontFamily = FontFamily.Serif)
+                        Text("Delete", fontFamily = GaeguRegular)
                     }
                 }
             }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
@@ -1,26 +1,15 @@
 package com.example.mygymapp.ui.pages
 
-import android.net.Uri
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
-import com.example.mygymapp.data.Exercise
-import com.example.mygymapp.model.ExerciseCategory
-import com.example.mygymapp.model.MuscleGroup
-import com.example.mygymapp.viewmodel.ExerciseViewModel
 
 @Composable
 fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
     val navController = rememberNavController()
-    val exerciseViewModel: ExerciseViewModel = viewModel()
 
     NavHost(navController = navController, startDestination = "lines") {
         composable("lines") {
@@ -36,71 +25,11 @@ fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
                 defaultValue = -1L
             })
         ) { backStackEntry ->
-            val editId = backStackEntry.arguments?.getLong("editId") ?: -1L
-            val exercisesState = exerciseViewModel.allExercises.observeAsState()
-            val editingExercise = exercisesState.value?.find { it.id == editId }
-
-            if (editId != -1L && editingExercise == null) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                }
-            } else {
-                MovementEntryPage(
-                    onSave = { name: String, category: String, muscleGroup: String, rating: Int, uri: Uri?, note: String ->
-                        val categoryEnum = ExerciseCategory.values().find { it.display == category } ?: ExerciseCategory.Calisthenics
-                        val muscleGroupEnum = MuscleGroup.values().find { it.display == muscleGroup } ?: MuscleGroup.Core
-
-                        val updatedExercise = Exercise(
-                            id = editingExercise?.id ?: 0,
-                            name = name,
-                            description = note,
-                            category = categoryEnum,
-                            likeability = rating,
-                            muscleGroup = muscleGroupEnum,
-                            muscle = muscleGroupEnum.display,
-                            imageUri = uri?.toString(),
-                            isFavorite = editingExercise?.isFavorite ?: false
-                        )
-
-                        if (editingExercise != null) {
-                            exerciseViewModel.update(updatedExercise)
-                        } else {
-                            exerciseViewModel.insert(updatedExercise)
-                        }
-
-                        navController.popBackStack()
-                    },
-                    onCancel = {
-                        navController.popBackStack()
-                    }
-                )
-            }
+            val editIdArg = backStackEntry.arguments?.getLong("editId")?.takeIf { it != -1L }
+            MovementEntryPage(navController = navController, editId = editIdArg)
         }
         composable("movement_editor") {
-            MovementEntryPage(
-                onSave = { name: String, category: String, muscleGroup: String, rating: Int, uri: Uri?, note: String ->
-                    val categoryEnum = ExerciseCategory.values().find { it.display == category } ?: ExerciseCategory.Calisthenics
-                    val muscleGroupEnum = MuscleGroup.values().find { it.display == muscleGroup } ?: MuscleGroup.Core
-
-                    val newExercise = Exercise(
-                        id = 0,
-                        name = name,
-                        description = note,
-                        category = categoryEnum,
-                        likeability = rating,
-                        muscleGroup = muscleGroupEnum,
-                        muscle = muscleGroupEnum.display,
-                        imageUri = uri?.toString(),
-                        isFavorite = false
-                    )
-
-                    exerciseViewModel.insert(newExercise)
-                    navController.popBackStack()
-                },
-                onCancel = {
-                    navController.popBackStack()
-                }
-            )
+            MovementEntryPage(navController = navController)
         }
     }
 }


### PR DESCRIPTION
## Summary
- make `MovementEntryPage` able to load and update exercises
- simplify navigation to pass the optional `editId`
- restyle `ExerciseManagementScreen` and `ExerciseCardWithHighlight` to match `MovementEntryPage`
- remove the reset button from the management screen

## Testing
- `./gradlew help --console=plain --quiet`
- `./gradlew test --console=plain --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea992f08832a9213dc4752938a71