### PR TITLE
Add LineParagraphPage with ParagraphCard

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Paragraph.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Paragraph.kt
@@ -1,0 +1,12 @@
+package com.example.mygymapp.model
+
+/**
+ * Represents a weekly "Paragraph" made up of seven training lines.
+ */
+data class Paragraph(
+    val id: Long,
+    val title: String,
+    val mood: String,
+    val tags: List<String>,
+    val lineTitles: List<String>
+)

--- a/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
@@ -1,0 +1,64 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Paragraph
+
+@Composable
+fun ParagraphCard(
+    paragraph: Paragraph,
+    onEdit: () -> Unit,
+    onPlan: () -> Unit,
+    onSaveTemplate: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = paragraph.title,
+                style = MaterialTheme.typography.headlineSmall.copy(fontFamily = FontFamily.Serif)
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "Mood: ${paragraph.mood}",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
+            )
+            if (paragraph.tags.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = paragraph.tags.joinToString(),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            paragraph.lineTitles.forEachIndexed { index, title ->
+                Text(
+                    text = "Day ${index + 1}: $title",
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextButton(onClick = onEdit) { Text("✏️ Edit") }
+                TextButton(onClick = onPlan) { Text("📆 Plan") }
+                TextButton(onClick = onSaveTemplate) { Text("📎 Save Template") }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -1,0 +1,109 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.ui.components.LineCard
+import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.components.ParagraphCard
+
+@Composable
+fun LineParagraphPage(
+    lines: List<Line>,
+    paragraphs: List<Paragraph>,
+    onAddLine: () -> Unit,
+    onAddParagraph: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var selectedTab by remember { mutableStateOf(0) }
+    val tabs = listOf("Lines", "Paragraphs")
+
+    PaperBackground(modifier = modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            TabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(title, fontFamily = FontFamily.Serif) }
+                    )
+                }
+            }
+
+            Crossfade(targetState = selectedTab, label = "tab") { tab ->
+                when (tab) {
+                    0 -> LinesList(lines)
+                    else -> ParagraphList(paragraphs)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = if (selectedTab == 0) onAddLine else onAddParagraph,
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .fillMaxWidth(),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Text(
+                    text = if (selectedTab == 0) "➕ Add Line" else "➕ Add Paragraph",
+                    fontFamily = FontFamily.Serif
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun LinesList(lines: List<Line>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(lines) { line ->
+            LineCard(
+                line = line,
+                onEdit = {},
+                onAdd = {},
+                onArchive = {},
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ParagraphList(paragraphs: List<Paragraph>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(paragraphs) { paragraph ->
+            ParagraphCard(
+                paragraph = paragraph,
+                onEdit = {},
+                onPlan = {},
+                onSaveTemplate = {},
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `Paragraph` model for weekly sections
- show paragraph info with new `ParagraphCard`
- implement `LineParagraphPage` with tabs for Lines and Paragraphs

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*
- `./gradlew test -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688caa7ba510832a94a501e518c7dc4b