### PR TITLE
Add ParagraphEditorPage for creating or editing paragraphs

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/ParagraphRepository.kt
+++ b/app/src/main/java/com/example/mygymapp/data/ParagraphRepository.kt
@@ -1,0 +1,24 @@
+package com.example.mygymapp.data
+
+import com.example.mygymapp.model.Paragraph
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+class ParagraphRepository {
+    private val _paragraphs = MutableStateFlow<List<Paragraph>>(emptyList())
+    val paragraphs = _paragraphs
+
+    fun add(paragraph: Paragraph) {
+        _paragraphs.update { it + paragraph }
+    }
+
+    fun edit(paragraph: Paragraph) {
+        _paragraphs.update { list ->
+            list.map { if (it.id == paragraph.id) paragraph else it }
+        }
+    }
+
+    fun delete(paragraph: Paragraph) {
+        _paragraphs.update { it.filterNot { p -> p.id == paragraph.id } }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/model/Paragraph.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Paragraph.kt
@@ -1,0 +1,12 @@
+package com.example.mygymapp.model
+
+/**
+ * Represents a weekly "Paragraph" made up of seven training lines.
+ */
+data class Paragraph(
+    val id: Long,
+    val title: String,
+    val mood: String,
+    val tags: List<String>,
+    val lineTitles: List<String>
+)

--- a/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
@@ -1,0 +1,64 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Paragraph
+
+@Composable
+fun ParagraphCard(
+    paragraph: Paragraph,
+    onEdit: () -> Unit,
+    onPlan: () -> Unit,
+    onSaveTemplate: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = paragraph.title,
+                style = MaterialTheme.typography.headlineSmall.copy(fontFamily = FontFamily.Serif)
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "Mood: ${paragraph.mood}",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
+            )
+            if (paragraph.tags.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = paragraph.tags.joinToString(),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            paragraph.lineTitles.forEachIndexed { index, title ->
+                Text(
+                    text = "Day ${index + 1}: $title",
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextButton(onClick = onEdit) { Text("✏️ Edit") }
+                TextButton(onClick = onPlan) { Text("📆 Plan") }
+                TextButton(onClick = onSaveTemplate) { Text("📎 Save Template") }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
@@ -13,7 +13,13 @@ fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
 
     NavHost(navController = navController, startDestination = "lines") {
         composable("lines") {
-            ArchivePage(onManageExercises = { navController.navigate("exercise_management") })
+            ArchivePage(
+                onManageExercises = { navController.navigate("exercise_management") },
+                onOpenLineParagraph = { navController.navigate("line_paragraph") }
+            )
+        }
+        composable("line_paragraph") {
+            LineParagraphPage()
         }
         composable("exercise_management") {
             ExerciseManagementScreen(navController = navController)

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchivePage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchivePage.kt
@@ -15,7 +15,10 @@ import com.example.mygymapp.model.ExerciseCategory
 import com.example.mygymapp.model.MuscleGroup
 
 @Composable
-fun ArchivePage(onManageExercises: () -> Unit) {
+fun ArchivePage(
+    onManageExercises: () -> Unit,
+    onOpenLineParagraph: () -> Unit
+) {
     val demoLines = remember {
         listOf(
             Line(
@@ -87,6 +90,21 @@ fun ArchivePage(onManageExercises: () -> Unit) {
         ) {
             Text(
                 text = "✍️ Edit Exercises",
+                fontFamily = FontFamily.Serif,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onOpenLineParagraph,
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp)
+        ) {
+            Text(
+                text = "📖 Lines & Paragraphs",
                 fontFamily = FontFamily.Serif,
                 modifier = Modifier.padding(vertical = 4.dp)
             )

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -1,0 +1,158 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.ui.components.LineCard
+import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.components.ParagraphCard
+import com.example.mygymapp.viewmodel.ParagraphViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun LineParagraphPage(
+    paragraphViewModel: ParagraphViewModel = viewModel(),
+    modifier: Modifier = Modifier
+) {
+    var selectedTab by remember { mutableStateOf(0) }
+    val tabs = listOf("Lines", "Paragraphs")
+    val paragraphs by paragraphViewModel.paragraphs.collectAsState()
+    var lines by remember { mutableStateOf(sampleLines()) }
+
+    PaperBackground(modifier = modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            TabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(title, fontFamily = FontFamily.Serif) }
+                    )
+                }
+            }
+
+            Crossfade(targetState = selectedTab, label = "tab") { tab ->
+                when (tab) {
+                    0 -> LinesList(lines)
+                    else -> ParagraphList(paragraphs, paragraphViewModel)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = {
+                    if (selectedTab == 0) {
+                        lines = lines + sampleLine(lines.size.toLong() + 1)
+                    } else {
+                        paragraphViewModel.addParagraph(sampleParagraph())
+                    }
+                },
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .fillMaxWidth(),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Text(
+                    text = if (selectedTab == 0) "➕ Add Line" else "➕ Add Paragraph",
+                    fontFamily = FontFamily.Serif
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun LinesList(lines: List<Line>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(lines) { line ->
+            LineCard(
+                line = line,
+                onEdit = {},
+                onAdd = {},
+                onArchive = {},
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ParagraphList(paragraphs: List<Paragraph>, vm: ParagraphViewModel) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        items(paragraphs) { paragraph ->
+            ParagraphCard(
+                paragraph = paragraph,
+                onEdit = { vm.editParagraph(paragraph) },
+                onPlan = {},
+                onSaveTemplate = {},
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+    }
+}
+
+private fun sampleLines(): List<Line> = listOf(
+    Line(
+        id = 1,
+        title = "Silent Force",
+        category = "Push",
+        muscleGroup = "Core",
+        mood = "balanced",
+        exercises = emptyList(),
+        supersets = emptyList(),
+        note = "Felt steady and grounded."
+    ),
+    Line(
+        id = 2,
+        title = "Night Owl Session",
+        category = "Pull",
+        muscleGroup = "Back",
+        mood = "alert",
+        exercises = emptyList(),
+        supersets = emptyList(),
+        note = "Late session with high focus."
+    )
+)
+
+private fun sampleLine(id: Long): Line = Line(
+    id = id,
+    title = "New Line $id",
+    category = "Push",
+    muscleGroup = "Full",
+    mood = "calm",
+    exercises = emptyList(),
+    supersets = emptyList(),
+    note = ""
+)
+
+private fun sampleParagraph(): Paragraph = Paragraph(
+    id = System.currentTimeMillis(),
+    title = "Weekly Notes",
+    mood = "reflective",
+    tags = emptyList(),
+    lineTitles = List(7) { "Line ${it + 1}" }
+)
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPage.kt
@@ -1,0 +1,124 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.ui.components.PaperBackground
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ParagraphEditorPage(
+    initial: Paragraph?,
+    onSave: (Paragraph) -> Unit,
+    onCancel: () -> Unit
+) {
+    var title by remember { mutableStateOf(initial?.title ?: "") }
+    var mood by remember { mutableStateOf(initial?.mood ?: "") }
+    var tagsText by remember { mutableStateOf(initial?.tags?.joinToString(", ") ?: "") }
+    var lineTitles by remember { mutableStateOf(initial?.lineTitles ?: List(7) { "" }) }
+
+    var moodExpanded by remember { mutableStateOf(false) }
+    val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
+
+    ModalBottomSheet(
+        onDismissRequest = onCancel,
+        sheetState = rememberModalBottomSheetState()
+    ) {
+        PaperBackground {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+            ) {
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    label = { Text("Title", fontFamily = FontFamily.Serif) },
+                    textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(Modifier.height(8.dp))
+
+                ExposedDropdownMenuBox(
+                    expanded = moodExpanded,
+                    onExpandedChange = { moodExpanded = !moodExpanded }
+                ) {
+                    OutlinedTextField(
+                        value = mood,
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Mood", fontFamily = FontFamily.Serif) },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(moodExpanded) },
+                        modifier = Modifier.fillMaxWidth(),
+                        textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif)
+                    )
+                    ExposedDropdownMenu(
+                        expanded = moodExpanded,
+                        onDismissRequest = { moodExpanded = false }
+                    ) {
+                        moods.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(option, fontFamily = FontFamily.Serif) },
+                                onClick = {
+                                    mood = option
+                                    moodExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                lineTitles.forEachIndexed { index, value ->
+                    OutlinedTextField(
+                        value = value,
+                        onValueChange = { newValue ->
+                            lineTitles = lineTitles.toMutableList().also { it[index] = newValue }
+                        },
+                        label = { Text("Day ${index + 1}", fontFamily = FontFamily.Serif) },
+                        textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    )
+                }
+
+                OutlinedTextField(
+                    value = tagsText,
+                    onValueChange = { tagsText = it },
+                    label = { Text("Tags (comma separated)", fontFamily = FontFamily.Serif) },
+                    textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(Modifier.height(16.dp))
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onCancel) { Text("Cancel", fontFamily = FontFamily.Serif) }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = {
+                        val tags = tagsText.split(',').map { it.trim() }.filter { it.isNotBlank() }
+                        val paragraph = Paragraph(
+                            id = initial?.id ?: System.currentTimeMillis(),
+                            title = title,
+                            mood = mood,
+                            tags = tags,
+                            lineTitles = lineTitles
+                        )
+                        onSave(paragraph)
+                    }) {
+                        Text("Save", fontFamily = FontFamily.Serif)
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.mygymapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mygymapp.data.ParagraphRepository
+import com.example.mygymapp.model.Paragraph
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ParagraphViewModel(
+    private val repo: ParagraphRepository = ParagraphRepository()
+) : ViewModel() {
+    private val _paragraphs = MutableStateFlow<List<Paragraph>>(emptyList())
+    val paragraphs: StateFlow<List<Paragraph>> = _paragraphs.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repo.paragraphs.collect { _paragraphs.value = it }
+        }
+    }
+
+    fun addParagraph(paragraph: Paragraph) = repo.add(paragraph)
+    fun editParagraph(paragraph: Paragraph) = repo.edit(paragraph)
+    fun deleteParagraph(paragraph: Paragraph) = repo.delete(paragraph)
+}


### PR DESCRIPTION
## Summary
- implement `ParagraphEditorPage` as a bottom sheet editor for paragraphs
- allow editing title, mood, line titles and tags in a paper themed layout

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*
- `./gradlew test -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688caa7ba510832a94a501e518c7dc4b