### PR TITLE
Add paragraph planning and templates

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/PlannedParagraph.kt
+++ b/app/src/main/java/com/example/mygymapp/model/PlannedParagraph.kt
@@ -1,0 +1,9 @@
+package com.example.mygymapp.model
+
+import java.time.LocalDate
+
+/** Represents a paragraph with a chosen start date. */
+data class PlannedParagraph(
+    val paragraph: Paragraph,
+    val startDate: LocalDate
+)

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -9,15 +9,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.model.PlannedParagraph
 import com.example.mygymapp.ui.components.LineCard
 import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.components.ParagraphCard
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import com.example.mygymapp.viewmodel.ParagraphViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 
@@ -29,9 +37,13 @@ fun LineParagraphPage(
     var selectedTab by remember { mutableStateOf(0) }
     val tabs = listOf("Lines", "Paragraphs")
     val paragraphs by paragraphViewModel.paragraphs.collectAsState()
+    val templates by paragraphViewModel.templates.collectAsState()
+    val planned by paragraphViewModel.planned.collectAsState()
     var lines by remember { mutableStateOf(sampleLines()) }
     var editingParagraph by remember { mutableStateOf<Paragraph?>(null) }
     var showEditor by remember { mutableStateOf(false) }
+    var planTarget by remember { mutableStateOf<Paragraph?>(null) }
+    var showTemplateChooser by remember { mutableStateOf(false) }
 
     PaperBackground(modifier = modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {
@@ -48,10 +60,16 @@ fun LineParagraphPage(
             Crossfade(targetState = selectedTab, label = "tab") { tab ->
                 when (tab) {
                     0 -> LinesList(lines)
-                    else -> ParagraphList(paragraphs) { paragraph ->
-                        editingParagraph = paragraph
-                        showEditor = true
-                    }
+                    else -> ParagraphList(
+                        paragraphs = paragraphs,
+                        plannedParagraphs = planned,
+                        onEdit = { paragraph ->
+                            editingParagraph = paragraph
+                            showEditor = true
+                        },
+                        onPlan = { planTarget = it },
+                        onSaveTemplate = { paragraphViewModel.saveTemplate(it) }
+                    )
                 }
             }
 
@@ -61,8 +79,12 @@ fun LineParagraphPage(
                     if (selectedTab == 0) {
                         lines = lines + sampleLine(lines.size.toLong() + 1)
                     } else {
-                        editingParagraph = null
-                        showEditor = true
+                        if (templates.isNotEmpty()) {
+                            showTemplateChooser = true
+                        } else {
+                            editingParagraph = null
+                            showEditor = true
+                        }
                     }
                 },
                 modifier = Modifier
@@ -93,6 +115,51 @@ fun LineParagraphPage(
             onCancel = { showEditor = false }
         )
     }
+
+    planTarget?.let { target ->
+        val dateState = rememberDatePickerState()
+        ModalBottomSheet(onDismissRequest = { planTarget = null }) {
+            Column(Modifier.padding(16.dp)) {
+                DatePicker(state = dateState)
+                Spacer(Modifier.height(8.dp))
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { planTarget = null }) {
+                        Text("Cancel", fontFamily = FontFamily.Serif)
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = {
+                        val millis = dateState.selectedDateMillis ?: return@Button
+                        val date = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+                        paragraphViewModel.planParagraph(target, date)
+                        planTarget = null
+                    }) {
+                        Text("Plan", fontFamily = FontFamily.Serif)
+                    }
+                }
+            }
+        }
+    }
+
+    if (showTemplateChooser) {
+        ModalBottomSheet(onDismissRequest = { showTemplateChooser = false }) {
+            Column(Modifier.padding(16.dp)) {
+                Text("Choose Template", fontFamily = FontFamily.Serif, style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.height(8.dp))
+                templates.forEach { template ->
+                    TextButton(onClick = {
+                        editingParagraph = template
+                        showTemplateChooser = false
+                        showEditor = true
+                    }) { Text(template.title, fontFamily = FontFamily.Serif) }
+                }
+                TextButton(onClick = {
+                    editingParagraph = null
+                    showTemplateChooser = false
+                    showEditor = true
+                }) { Text("Blank", fontFamily = FontFamily.Serif) }
+            }
+        }
+    }
 }
 
 @Composable
@@ -118,7 +185,10 @@ private fun LinesList(lines: List<Line>) {
 @Composable
 private fun ParagraphList(
     paragraphs: List<Paragraph>,
-    onEdit: (Paragraph) -> Unit
+    plannedParagraphs: List<PlannedParagraph>,
+    onEdit: (Paragraph) -> Unit,
+    onPlan: (Paragraph) -> Unit,
+    onSaveTemplate: (Paragraph) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -130,10 +200,35 @@ private fun ParagraphList(
             ParagraphCard(
                 paragraph = paragraph,
                 onEdit = { onEdit(paragraph) },
-                onPlan = {},
-                onSaveTemplate = {},
+                onPlan = { onPlan(paragraph) },
+                onSaveTemplate = { onSaveTemplate(paragraph) },
                 modifier = Modifier.padding(horizontal = 24.dp)
             )
+        }
+        if (plannedParagraphs.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Planned paragraphs:",
+                    fontFamily = FontFamily.Serif,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+            }
+            items(plannedParagraphs) { planned ->
+                ParagraphCard(
+                    paragraph = planned.paragraph,
+                    onEdit = {},
+                    onPlan = {},
+                    onSaveTemplate = {},
+                    modifier = Modifier.padding(horizontal = 24.dp)
+                )
+                Text(
+                    text = "Start: ${planned.startDate}",
+                    fontFamily = FontFamily.Serif,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 28.dp, vertical = 4.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.mygymapp.data.ParagraphRepository
 import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.model.PlannedParagraph
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class ParagraphViewModel(
@@ -14,6 +17,12 @@ class ParagraphViewModel(
 ) : ViewModel() {
     private val _paragraphs = MutableStateFlow<List<Paragraph>>(emptyList())
     val paragraphs: StateFlow<List<Paragraph>> = _paragraphs.asStateFlow()
+
+    private val _templates = MutableStateFlow<List<Paragraph>>(emptyList())
+    val templates: StateFlow<List<Paragraph>> = _templates.asStateFlow()
+
+    private val _planned = MutableStateFlow<List<PlannedParagraph>>(emptyList())
+    val planned: StateFlow<List<PlannedParagraph>> = _planned.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -24,4 +33,12 @@ class ParagraphViewModel(
     fun addParagraph(paragraph: Paragraph) = repo.add(paragraph)
     fun editParagraph(paragraph: Paragraph) = repo.edit(paragraph)
     fun deleteParagraph(paragraph: Paragraph) = repo.delete(paragraph)
+
+    fun saveTemplate(paragraph: Paragraph) {
+        _templates.update { it + paragraph.copy() }
+    }
+
+    fun planParagraph(paragraph: Paragraph, startDate: LocalDate) {
+        _planned.update { it + PlannedParagraph(paragraph, startDate) }
+    }
 }


### PR DESCRIPTION
## Summary
- add `PlannedParagraph` data model for planned weeks
- extend `ParagraphViewModel` with template and planning flows
- show plan & template options in `LineParagraphPage`

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cb6db3c10832a8968c8ed315dfdd9