### PR TITLE
Implement line repository and view model

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/LineRepository.kt
+++ b/app/src/main/java/com/example/mygymapp/data/LineRepository.kt
@@ -1,0 +1,33 @@
+package com.example.mygymapp.data
+
+import com.example.mygymapp.model.Line
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+class LineRepository {
+    private val _lines = MutableStateFlow<List<Line>>(emptyList())
+    val lines: StateFlow<List<Line>> = _lines
+
+    fun add(line: Line) {
+        _lines.update { it + line }
+    }
+
+    fun update(line: Line) {
+        _lines.update { list ->
+            list.map { if (it.id == line.id) line else it }
+        }
+    }
+
+    fun archive(lineId: Long) {
+        _lines.update { list ->
+            list.map { if (it.id == lineId) it.copy(isArchived = true) else it }
+        }
+    }
+
+    fun unarchive(lineId: Long) {
+        _lines.update { list ->
+            list.map { if (it.id == lineId) it.copy(isArchived = false) else it }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -28,6 +28,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import com.example.mygymapp.viewmodel.ParagraphViewModel
+import com.example.mygymapp.viewmodel.LineViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,7 +41,8 @@ fun LineParagraphPage(
     val paragraphs by paragraphViewModel.paragraphs.collectAsState()
     val templates by paragraphViewModel.templates.collectAsState()
     val planned by paragraphViewModel.planned.collectAsState()
-    var lines by remember { mutableStateOf(sampleLines()) }
+    val lineViewModel: LineViewModel = viewModel()
+    val lines by lineViewModel.lines.collectAsState()
     var editingParagraph by remember { mutableStateOf<Paragraph?>(null) }
     var showEditor by remember { mutableStateOf(false) }
     var planTarget by remember { mutableStateOf<Paragraph?>(null) }
@@ -60,7 +62,12 @@ fun LineParagraphPage(
 
             Crossfade(targetState = selectedTab, label = "tab") { tab ->
                 when (tab) {
-                    0 -> LinesList(lines)
+                    0 -> LinesList(
+                        lines = lines.filter { !it.isArchived },
+                        onEdit = { /* TODO */ },
+                        onAdd = { /* TODO */ },
+                        onArchive = { lineViewModel.archive(it.id) }
+                    )
                     else -> ParagraphList(
                         paragraphs = paragraphs,
                         plannedParagraphs = planned,
@@ -78,7 +85,7 @@ fun LineParagraphPage(
             Button(
                 onClick = {
                     if (selectedTab == 0) {
-                        lines = lines + sampleLine(lines.size.toLong() + 1)
+                        lineViewModel.add(sampleLine(lines.size.toLong() + 1))
                     } else {
                         if (templates.isNotEmpty()) {
                             showTemplateChooser = true
@@ -164,7 +171,12 @@ fun LineParagraphPage(
 }
 
 @Composable
-private fun LinesList(lines: List<Line>) {
+private fun LinesList(
+    lines: List<Line>,
+    onEdit: (Line) -> Unit,
+    onAdd: (Line) -> Unit,
+    onArchive: (Line) -> Unit
+) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -174,9 +186,9 @@ private fun LinesList(lines: List<Line>) {
         items(lines) { line ->
             LineCard(
                 line = line,
-                onEdit = {},
-                onAdd = {},
-                onArchive = {},
+                onEdit = { onEdit(line) },
+                onAdd = { onAdd(line) },
+                onArchive = { onArchive(line) },
                 modifier = Modifier.padding(horizontal = 24.dp)
             )
         }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/LineViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/LineViewModel.kt
@@ -1,0 +1,43 @@
+package com.example.mygymapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.example.mygymapp.data.LineRepository
+import com.example.mygymapp.model.Line
+import kotlinx.coroutines.flow.StateFlow
+
+class LineViewModel : ViewModel() {
+    private val repo = LineRepository()
+    val lines: StateFlow<List<Line>> = repo.lines
+
+    init {
+        add(
+            Line(
+                id = 1L,
+                title = "Silent Force",
+                category = "Push",
+                muscleGroup = "Core",
+                mood = "balanced",
+                exercises = emptyList(),
+                supersets = emptyList(),
+                note = "Felt steady and grounded throughout."
+            )
+        )
+        add(
+            Line(
+                id = 2L,
+                title = "Night Owl Session",
+                category = "Pull",
+                muscleGroup = "Back",
+                mood = "alert",
+                exercises = emptyList(),
+                supersets = listOf(1L to 2L),
+                note = "Late session with high focus."
+            )
+        )
+    }
+
+    fun add(line: Line) = repo.add(line)
+    fun update(line: Line) = repo.update(line)
+    fun archive(lineId: Long) = repo.archive(lineId)
+    fun unarchive(lineId: Long) = repo.unarchive(lineId)
+}


### PR DESCRIPTION
## Summary
- add `LineRepository` for dynamic state handling of lines
- introduce `LineViewModel` with sample data
- wire `LineParagraphPage` to `LineViewModel` and update `LinesList`

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc1cb2078832a900d050daceaa058