### PR TITLE
Fix parameter binding in PlanDao

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/PlanDao.kt
+++ b/app/src/main/java/com/example/mygymapp/data/PlanDao.kt
@@ -15,8 +15,8 @@ interface PlanDao {
     fun getAllPlans(): List<Plan>
 
     @Transaction
-    @Query("SELECT * FROM plan WHERE planId = :id")
-    fun getPlanWithExercises(id: Long): PlanWithExercises?
+    @Query("SELECT * FROM plan WHERE planId = :planId")
+    fun getPlanWithExercises(planId: Long): PlanWithExercises?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertPlan(plan: Plan): Long


### PR DESCRIPTION
## Summary
- fix parameter name for `getPlanWithExercises` in `PlanDao`

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd56c3ab8832ab72ab769258620cf