### PR TITLE
Add advanced exercise picker to LineEditorPage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Exercise.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Exercise.kt
@@ -4,5 +4,7 @@ data class Exercise(
     val id: Long,
     val name: String,
     val sets: Int,
-    val repsOrDuration: String
+    val repsOrDuration: String,
+    val prGoal: Int? = null,
+    val note: String = ""
 )


### PR DESCRIPTION
## Summary
- extend Exercise model with PR goal and note
- rework LineEditorPage to include search/filter for exercises
- add configuration sheet when adding an exercise
- allow selecting exercises to link as supersets

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d29b5d73c832a8063c20f544b22dc