### PR TITLE
Add LinesPage for viewing lines

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.model.PlannedParagraph
-import com.example.mygymapp.ui.components.LineCard
+import com.example.mygymapp.ui.pages.LinesPage
 import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.components.ParagraphCard
 import java.time.Instant
@@ -72,23 +72,15 @@ fun LineParagraphPage(
 
             Crossfade(targetState = selectedTab, label = "tab") { tab ->
                 when (tab) {
-                    0 -> Column(Modifier.fillMaxSize()) {
-                        TextButton(
-                            onClick = { navController.navigate("exercise_management") },
-                            modifier = Modifier.align(Alignment.End)
-                        ) {
-                            Text("⚙️ Manage Exercises")
-                        }
-                        LinesList(
-                            lines = lines.filter { !it.isArchived },
-                            onEdit = {
-                                editingLine = it
-                                showLineEditor = true
-                            },
-                            onAdd = { /* TODO */ },
-                            onArchive = { lineViewModel.archive(it.id) }
-                        )
-                    }
+                    0 -> LinesPage(
+                        lines = lines.filter { !it.isArchived },
+                        onEdit = {
+                            editingLine = it
+                            showLineEditor = true
+                        },
+                        onArchive = { lineViewModel.archive(it.id) },
+                        onManageExercises = { navController.navigate("exercise_management") }
+                    )
                     else -> ParagraphList(
                         paragraphs = paragraphs,
                         plannedParagraphs = planned,
@@ -124,7 +116,7 @@ fun LineParagraphPage(
                 shape = MaterialTheme.shapes.medium
             ) {
                 Text(
-                    text = if (selectedTab == 0) "➕ Add Line" else "➕ Add Paragraph",
+                    text = if (selectedTab == 0) "➕ Write a new line" else "➕ Add Paragraph",
                     fontFamily = FontFamily.Serif
                 )
             }
@@ -201,31 +193,6 @@ fun LineParagraphPage(
                     showEditor = true
                 }) { Text("Blank", fontFamily = FontFamily.Serif) }
             }
-        }
-    }
-}
-
-@Composable
-private fun LinesList(
-    lines: List<Line>,
-    onEdit: (Line) -> Unit,
-    onAdd: (Line) -> Unit,
-    onArchive: (Line) -> Unit
-) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        items(lines) { line ->
-            LineCard(
-                line = line,
-                onEdit = { onEdit(line) },
-                onAdd = { onAdd(line) },
-                onArchive = { onArchive(line) },
-                modifier = Modifier.padding(horizontal = 24.dp)
-            )
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
@@ -1,0 +1,86 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mygymapp.model.Line
+
+@Composable
+fun LinesPage(
+    lines: List<Line>,
+    onEdit: (Line) -> Unit,
+    onArchive: (Line) -> Unit,
+    onManageExercises: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier.fillMaxSize()) {
+        TextButton(
+            onClick = onManageExercises,
+            modifier = Modifier.align(Alignment.End)
+        ) {
+            Text("\u2699\uFE0F Manage Exercises", fontFamily = GaeguRegular)
+        }
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(lines) { line ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1))
+                ) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text(
+                            line.title,
+                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 22.sp)
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "${line.category} · ${line.muscleGroup} · ${line.mood}",
+                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 18.sp)
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        val supersetInfo = if (line.supersets.isNotEmpty()) " • ${line.supersets.size} supersets" else ""
+                        Text(
+                            "${line.exercises.size} exercises$supersetInfo",
+                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp)
+                        )
+                        if (line.note.isNotBlank()) {
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                "\uD83D\uDCCC ${line.note}",
+                                style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp)
+                            )
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            TextButton(onClick = { onEdit(line) }) {
+                                Text("\u270F\uFE0F Edit", fontFamily = GaeguRegular)
+                            }
+                            TextButton(onClick = { onArchive(line) }) {
+                                Text("\uD83D\uDCC3 Archive", fontFamily = GaeguRegular)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `LinesPage` composable showing stored lines in a parchment style
- embed `LinesPage` in `LineParagraphPage`
- tweak bottom button text to "➕ Write a new line" when viewing lines

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3ea07578832ab0acb0a145b2fe19