### PR TITLE
Add top add button for LinesPage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -74,6 +74,10 @@ fun LineParagraphPage(
                 when (tab) {
                     0 -> LinesPage(
                         lines = lines.filter { !it.isArchived },
+                        onAdd = {
+                            editingLine = null
+                            showLineEditor = true
+                        },
                         onEdit = {
                             editingLine = it
                             showLineEditor = true

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
@@ -20,12 +20,21 @@ import com.example.mygymapp.model.Line
 @Composable
 fun LinesPage(
     lines: List<Line>,
+    onAdd: () -> Unit,
     onEdit: (Line) -> Unit,
     onArchive: (Line) -> Unit,
     onManageExercises: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier.fillMaxSize()) {
+        TextButton(
+            onClick = onAdd,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 8.dp)
+        ) {
+            Text("\u2795 Write a new line", fontFamily = GaeguRegular)
+        }
         TextButton(
             onClick = onManageExercises,
             modifier = Modifier.align(Alignment.End)


### PR DESCRIPTION
## Summary
- allow LinesPage to accept an `onAdd` callback
- show a poetic "➕ Write a new line" button above the list
- pass add handler from LineParagraphPage to open line editor

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_688dd67748d0832a88a9d3723159dc75