### PR TITLE
feat: add paragraph overview page

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Paragraph.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Paragraph.kt
@@ -8,5 +8,6 @@ data class Paragraph(
     val title: String,
     val mood: String,
     val tags: List<String>,
-    val lineTitles: List<String>
+    val lineTitles: List<String>,
+    val note: String = ""
 )

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -2,8 +2,6 @@ package com.example.mygymapp.ui.pages
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
@@ -24,7 +22,7 @@ import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.model.PlannedParagraph
 import com.example.mygymapp.ui.pages.LinesPage
 import com.example.mygymapp.ui.components.PaperBackground
-import com.example.mygymapp.ui.components.ParagraphCard
+import com.example.mygymapp.ui.pages.ParagraphsPage
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -85,9 +83,9 @@ fun LineParagraphPage(
                         onArchive = { lineViewModel.archive(it.id) },
                         onManageExercises = { navController.navigate("exercise_management") }
                     )
-                    else -> ParagraphList(
+                    else -> ParagraphsPage(
                         paragraphs = paragraphs,
-                        plannedParagraphs = planned,
+                        planned = planned,
                         onEdit = { paragraph ->
                             editingParagraph = paragraph
                             showEditor = true
@@ -196,57 +194,6 @@ fun LineParagraphPage(
                     showTemplateChooser = false
                     showEditor = true
                 }) { Text("Blank", fontFamily = FontFamily.Serif) }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ParagraphList(
-    paragraphs: List<Paragraph>,
-    plannedParagraphs: List<PlannedParagraph>,
-    onEdit: (Paragraph) -> Unit,
-    onPlan: (Paragraph) -> Unit,
-    onSaveTemplate: (Paragraph) -> Unit
-) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        items(paragraphs) { paragraph ->
-            ParagraphCard(
-                paragraph = paragraph,
-                onEdit = { onEdit(paragraph) },
-                onPlan = { onPlan(paragraph) },
-                onSaveTemplate = { onSaveTemplate(paragraph) },
-                modifier = Modifier.padding(horizontal = 24.dp)
-            )
-        }
-        if (plannedParagraphs.isNotEmpty()) {
-            item {
-                Text(
-                    text = "Planned paragraphs:",
-                    fontFamily = FontFamily.Serif,
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                )
-            }
-            items(plannedParagraphs) { planned ->
-                ParagraphCard(
-                    paragraph = planned.paragraph,
-                    onEdit = {},
-                    onPlan = {},
-                    onSaveTemplate = {},
-                    modifier = Modifier.padding(horizontal = 24.dp)
-                )
-                Text(
-                    text = "Start: ${planned.startDate}",
-                    fontFamily = FontFamily.Serif,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(horizontal = 28.dp, vertical = 4.dp)
-                )
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPage.kt
@@ -22,6 +22,7 @@ fun ParagraphEditorPage(
     var mood by remember { mutableStateOf(initial?.mood ?: "") }
     var tagsText by remember { mutableStateOf(initial?.tags?.joinToString(", ") ?: "") }
     var lineTitles by remember { mutableStateOf(initial?.lineTitles ?: List(7) { "" }) }
+    var note by remember { mutableStateOf(initial?.note ?: "") }
 
     var moodExpanded by remember { mutableStateOf(false) }
     val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
@@ -99,6 +100,16 @@ fun ParagraphEditorPage(
                     modifier = Modifier.fillMaxWidth()
                 )
 
+                Spacer(Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it },
+                    label = { Text("Note", fontFamily = FontFamily.Serif) },
+                    textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
                 Spacer(Modifier.height(16.dp))
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                     TextButton(onClick = onCancel) { Text("Cancel", fontFamily = FontFamily.Serif) }
@@ -110,7 +121,8 @@ fun ParagraphEditorPage(
                             title = title,
                             mood = mood,
                             tags = tags,
-                            lineTitles = lineTitles
+                            lineTitles = lineTitles,
+                            note = note
                         )
                         onSave(paragraph)
                     }) {

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphsPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphsPage.kt
@@ -1,0 +1,136 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.model.PlannedParagraph
+import com.example.mygymapp.ui.components.PaperBackground
+
+/**
+ * Displays a poetic list of paragraphs and planned paragraphs.
+ */
+@Composable
+fun ParagraphsPage(
+    paragraphs: List<Paragraph>,
+    planned: List<PlannedParagraph>,
+    onEdit: (Paragraph) -> Unit,
+    onPlan: (Paragraph) -> Unit,
+    onSaveTemplate: (Paragraph) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    PaperBackground(modifier = modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(paragraphs) { paragraph ->
+                ParagraphEntryCard(
+                    paragraph = paragraph,
+                    onEdit = { onEdit(paragraph) },
+                    onPlan = { onPlan(paragraph) },
+                    onSaveTemplate = { onSaveTemplate(paragraph) }
+                )
+            }
+            if (planned.isNotEmpty()) {
+                item {
+                    Text(
+                        text = "Planned paragraphs:",
+                        style = TextStyle(fontFamily = GaeguBold, fontSize = 20.sp),
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                }
+                items(planned) { plannedParagraph ->
+                    Column {
+                        ParagraphEntryCard(
+                            paragraph = plannedParagraph.paragraph,
+                            onEdit = {},
+                            onPlan = {},
+                            onSaveTemplate = {},
+                            showButtons = false
+                        )
+                        Text(
+                            text = "Starts on: ${plannedParagraph.startDate}",
+                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp),
+                            modifier = Modifier.padding(horizontal = 28.dp, vertical = 4.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ParagraphEntryCard(
+    paragraph: Paragraph,
+    onEdit: () -> Unit,
+    onPlan: () -> Unit,
+    onSaveTemplate: () -> Unit,
+    modifier: Modifier = Modifier,
+    showButtons: Boolean = true
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1))
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                text = paragraph.title,
+                style = TextStyle(fontFamily = GaeguBold, fontSize = 22.sp)
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = paragraph.mood,
+                style = TextStyle(fontFamily = GaeguRegular, fontSize = 18.sp)
+            )
+            Spacer(Modifier.height(4.dp))
+            val days = listOf("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+            paragraph.lineTitles.forEachIndexed { index, title ->
+                if (title.isNotBlank()) {
+                    Text(
+                        text = "${days.getOrNull(index) ?: "Day ${index + 1}"} \u2192 $title",
+                        style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp)
+                    )
+                }
+            }
+            if (paragraph.note.isNotBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "\uD83D\uDCCC ${paragraph.note}",
+                    style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp)
+                )
+            }
+            if (showButtons) {
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    TextButton(onClick = onEdit) {
+                        Text("\u270F\uFE0F Edit", fontFamily = GaeguRegular)
+                    }
+                    TextButton(onClick = onPlan) {
+                        Text("\uD83D\uDCC6 Plan", fontFamily = GaeguRegular)
+                    }
+                    TextButton(onClick = onSaveTemplate) {
+                        Text("\uD83D\uDCCE Save as Template", fontFamily = GaeguRegular)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new ParagraphsPage with parchment-like cards and planning section
- support notes for paragraphs and allow editing them
- integrate ParagraphsPage into LineParagraphPage

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd98b7960832a8f1e823a74babd13