### PR TITLE
Use parchment-themed line card

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -1,21 +1,26 @@
 package com.example.mygymapp.ui.components
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.ui.unit.sp
+import com.example.mygymapp.R
 import com.example.mygymapp.model.Line
-import androidx.compose.runtime.getValue
 
 @Composable
 fun LineCard(
@@ -26,10 +31,16 @@ fun LineCard(
     modifier: Modifier = Modifier
 ) {
     val fade by animateFloatAsState(if (line.isArchived) 0f else 1f, label = "fade")
+    val gaeguRegular = FontFamily(Font(R.font.gaegu_regular))
+    val gaeguBold = FontFamily(Font(R.font.gaegu_bold))
+    val gaeguLight = FontFamily(Font(R.font.gaegu_light))
+    val textColor = Color(0xFF5D4037)
+    val buttonBackground = Color(0xFFFFF8E1)
 
     Card(
         modifier = modifier
             .fillMaxWidth()
+            .padding(vertical = 8.dp)
             .alpha(fade),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
@@ -38,32 +49,81 @@ fun LineCard(
         Column(modifier = Modifier.padding(20.dp)) {
             Text(
                 text = line.title,
-                style = MaterialTheme.typography.headlineSmall
+                style = TextStyle(
+                    fontFamily = gaeguBold,
+                    fontSize = 24.sp,
+                    color = textColor
+                )
             )
             Spacer(modifier = Modifier.height(6.dp))
             Text(
                 text = "${line.category} · ${line.muscleGroup} · ${line.mood}",
-                style = MaterialTheme.typography.bodySmall
+                style = TextStyle(
+                    fontFamily = gaeguRegular,
+                    fontSize = 14.sp,
+                    color = textColor
+                )
             )
             Spacer(modifier = Modifier.height(6.dp))
             Text(
                 text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
-                style = MaterialTheme.typography.bodySmall
+                style = TextStyle(
+                    fontFamily = gaeguRegular,
+                    fontSize = 14.sp,
+                    color = textColor
+                )
             )
             if (line.note.isNotBlank()) {
                 Spacer(modifier = Modifier.height(6.dp))
                 Text(
                     text = "📎 ${line.note}",
-                    style = MaterialTheme.typography.bodySmall,
+                    style = TextStyle(
+                        fontFamily = gaeguLight,
+                        fontSize = 14.sp,
+                        color = textColor
+                    ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
             }
             Spacer(modifier = Modifier.height(12.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(onClick = onEdit) { Text("✏️ Edit") }
-                TextButton(onClick = onAdd) { Text("📥 Add") }
-                TextButton(onClick = onArchive) { Text("📦 Archive") }
+                TextButton(
+                    onClick = onEdit,
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = buttonBackground,
+                        contentColor = textColor
+                    )
+                ) {
+                    Text(
+                        "✏️ Edit",
+                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
+                    )
+                }
+                TextButton(
+                    onClick = onAdd,
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = buttonBackground,
+                        contentColor = textColor
+                    )
+                ) {
+                    Text(
+                        "📥 Add",
+                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
+                    )
+                }
+                TextButton(
+                    onClick = onArchive,
+                    colors = ButtonDefaults.textButtonColors(
+                        containerColor = buttonBackground,
+                        contentColor = textColor
+                    )
+                ) {
+                    Text(
+                        "📦 Archive",
+                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
@@ -1,21 +1,20 @@
 package com.example.mygymapp.ui.pages
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.example.mygymapp.R
 import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.components.LineCard
 
 @Composable
 fun LinesPage(
@@ -26,68 +25,41 @@ fun LinesPage(
     onManageExercises: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.fillMaxSize()) {
-        TextButton(
-            onClick = onAdd,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 8.dp)
-        ) {
-            Text("\u2795 Write a new line", fontFamily = GaeguRegular)
-        }
-        TextButton(
-            onClick = onManageExercises,
-            modifier = Modifier.align(Alignment.End)
-        ) {
-            Text("\u2699\uFE0F Manage Exercises", fontFamily = GaeguRegular)
-        }
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            items(lines) { line ->
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1))
-                ) {
-                    Column(Modifier.padding(16.dp)) {
-                        Text(
-                            line.title,
-                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 22.sp)
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            "${line.category} · ${line.muscleGroup} · ${line.mood}",
-                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 18.sp)
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        val supersetInfo = if (line.supersets.isNotEmpty()) " • ${line.supersets.size} supersets" else ""
-                        Text(
-                            "${line.exercises.size} exercises$supersetInfo",
-                            style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp)
-                        )
-                        if (line.note.isNotBlank()) {
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                "\uD83D\uDCCC ${line.note}",
-                                style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp)
-                            )
-                        }
-                        Spacer(Modifier.height(8.dp))
-                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                            TextButton(onClick = { onEdit(line) }) {
-                                Text("\u270F\uFE0F Edit", fontFamily = GaeguRegular)
-                            }
-                            TextButton(onClick = { onArchive(line) }) {
-                                Text("\uD83D\uDCC3 Archive", fontFamily = GaeguRegular)
-                            }
-                        }
-                    }
+    Box(modifier.fillMaxSize()) {
+        Image(
+            painter = painterResource(id = R.drawable.background_parchment),
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+        Column(Modifier.fillMaxSize()) {
+            TextButton(
+                onClick = onAdd,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 8.dp)
+            ) {
+                Text("\u2795 Write a new line", fontFamily = GaeguRegular)
+            }
+            TextButton(
+                onClick = onManageExercises,
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text("\u2699\uFE0F Manage Exercises", fontFamily = GaeguRegular)
+            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(lines) { line ->
+                    LineCard(
+                        line = line,
+                        onEdit = { onEdit(line) },
+                        onAdd = { onAdd() },
+                        onArchive = { onArchive(line) }
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Restyle LineCard with parchment background and Gaegu fonts
- Apply warm colors to text and buttons
- Replace MaterialTheme typography with direct TextStyle usage
- Use LineCard to render each training line on LinesPage

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de1b0a944832aa36d076ae66c38cd