### PR TITLE
Align lines & paragraphs UI with entry movement style

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.Image
-import androidx.compose.ui.res.painterResource
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
@@ -15,10 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.model.Line
@@ -28,7 +23,7 @@ import com.example.mygymapp.model.MuscleGroup
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.mygymapp.viewmodel.ExerciseViewModel
-import com.example.mygymapp.R
+import com.example.mygymapp.ui.components.PaperBackground
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.background
@@ -71,18 +66,12 @@ fun LineEditorPage(
     var showExercisePicker by remember { mutableStateOf(false) }
     var filtersVisible by remember { mutableStateOf(false) }
 
-    Box(
+    PaperBackground(
         modifier = Modifier
             .fillMaxSize()
             .systemBarsPadding()
             .imePadding()
     ) {
-        Image(
-            painter = painterResource(R.drawable.background_parchment),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.matchParentSize()
-        )
         Column(
             modifier = Modifier.padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
@@ -24,7 +23,6 @@ import com.example.mygymapp.ui.pages.LinesPage
 import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.pages.ParagraphsPage
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import com.example.mygymapp.viewmodel.ParagraphViewModel
 import com.example.mygymapp.viewmodel.LineViewModel
@@ -63,7 +61,7 @@ fun LineParagraphPage(
                     Tab(
                         selected = selectedTab == index,
                         onClick = { selectedTab = index },
-                        text = { Text(title, fontFamily = FontFamily.Serif) }
+                        text = { Text(title, fontFamily = GaeguRegular) }
                     )
                 }
             }
@@ -123,7 +121,7 @@ fun LineParagraphPage(
             ) {
                 Text(
                     text = if (selectedTab == 0) "➕ Write a new line" else "➕ Add Paragraph",
-                    fontFamily = FontFamily.Serif
+                    fontFamily = GaeguRegular
                 )
             }
             Spacer(modifier = Modifier.height(16.dp))
@@ -165,7 +163,7 @@ fun LineParagraphPage(
                 Spacer(Modifier.height(8.dp))
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                     TextButton(onClick = { planTarget = null }) {
-                        Text("Cancel", fontFamily = FontFamily.Serif)
+                        Text("Cancel", fontFamily = GaeguRegular)
                     }
                     Spacer(Modifier.width(8.dp))
                     Button(onClick = {
@@ -174,7 +172,7 @@ fun LineParagraphPage(
                         paragraphViewModel.planParagraph(target, date)
                         planTarget = null
                     }) {
-                        Text("Plan", fontFamily = FontFamily.Serif)
+                        Text("Plan", fontFamily = GaeguRegular)
                     }
                 }
             }
@@ -184,20 +182,20 @@ fun LineParagraphPage(
     if (showTemplateChooser) {
         ModalBottomSheet(onDismissRequest = { showTemplateChooser = false }) {
             Column(Modifier.padding(16.dp)) {
-                Text("Choose Template", fontFamily = FontFamily.Serif, style = MaterialTheme.typography.titleMedium)
+                Text("Choose Template", fontFamily = GaeguBold, style = MaterialTheme.typography.titleMedium)
                 Spacer(Modifier.height(8.dp))
                 templates.forEach { template ->
                     TextButton(onClick = {
                         editingParagraph = template
                         showTemplateChooser = false
                         showEditor = true
-                    }) { Text(template.title, fontFamily = FontFamily.Serif) }
+                    }) { Text(template.title, fontFamily = GaeguRegular) }
                 }
                 TextButton(onClick = {
                     editingParagraph = null
                     showTemplateChooser = false
                     showEditor = true
-                }) { Text("Blank", fontFamily = FontFamily.Serif) }
+                }) { Text("Blank", fontFamily = GaeguRegular) }
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
@@ -1,6 +1,5 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -9,12 +8,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.example.mygymapp.R
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.ui.components.LineCard
+import com.example.mygymapp.ui.components.PaperBackground
 
 @Composable
 fun LinesPage(
@@ -25,13 +22,7 @@ fun LinesPage(
     onManageExercises: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier.fillMaxSize()) {
-        Image(
-            painter = painterResource(id = R.drawable.background_parchment),
-            contentDescription = null,
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Crop
-        )
+    PaperBackground(modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {
             TextButton(
                 onClick = onAdd,

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPage.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.ui.components.PaperBackground
@@ -41,8 +40,8 @@ fun ParagraphEditorPage(
                 OutlinedTextField(
                     value = title,
                     onValueChange = { title = it },
-                    label = { Text("Title", fontFamily = FontFamily.Serif) },
-                    textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                    label = { Text("Title", fontFamily = GaeguRegular) },
+                    textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular),
                     modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(Modifier.height(8.dp))
@@ -55,10 +54,10 @@ fun ParagraphEditorPage(
                         value = mood,
                         onValueChange = {},
                         readOnly = true,
-                        label = { Text("Mood", fontFamily = FontFamily.Serif) },
+                        label = { Text("Mood", fontFamily = GaeguRegular) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(moodExpanded) },
                         modifier = Modifier.fillMaxWidth(),
-                        textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif)
+                        textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular)
                     )
                     ExposedDropdownMenu(
                         expanded = moodExpanded,
@@ -66,7 +65,7 @@ fun ParagraphEditorPage(
                     ) {
                         moods.forEach { option ->
                             DropdownMenuItem(
-                                text = { Text(option, fontFamily = FontFamily.Serif) },
+                                text = { Text(option, fontFamily = GaeguRegular) },
                                 onClick = {
                                     mood = option
                                     moodExpanded = false
@@ -84,8 +83,8 @@ fun ParagraphEditorPage(
                         onValueChange = { newValue ->
                             lineTitles = lineTitles.toMutableList().also { it[index] = newValue }
                         },
-                        label = { Text("Day ${index + 1}", fontFamily = FontFamily.Serif) },
-                        textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                        label = { Text("Day ${index + 1}", fontFamily = GaeguRegular) },
+                        textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = 8.dp)
@@ -95,8 +94,8 @@ fun ParagraphEditorPage(
                 OutlinedTextField(
                     value = tagsText,
                     onValueChange = { tagsText = it },
-                    label = { Text("Tags (comma separated)", fontFamily = FontFamily.Serif) },
-                    textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                    label = { Text("Tags (comma separated)", fontFamily = GaeguRegular) },
+                    textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular),
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -105,14 +104,14 @@ fun ParagraphEditorPage(
                 OutlinedTextField(
                     value = note,
                     onValueChange = { note = it },
-                    label = { Text("Note", fontFamily = FontFamily.Serif) },
-                    textStyle = LocalTextStyle.current.copy(fontFamily = FontFamily.Serif),
+                    label = { Text("Note", fontFamily = GaeguRegular) },
+                    textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular),
                     modifier = Modifier.fillMaxWidth()
                 )
 
                 Spacer(Modifier.height(16.dp))
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                    TextButton(onClick = onCancel) { Text("Cancel", fontFamily = FontFamily.Serif) }
+                    TextButton(onClick = onCancel) { Text("Cancel", fontFamily = GaeguRegular) }
                     Spacer(Modifier.width(8.dp))
                     Button(onClick = {
                         val tags = tagsText.split(',').map { it.trim() }.filter { it.isNotBlank() }
@@ -126,7 +125,7 @@ fun ParagraphEditorPage(
                         )
                         onSave(paragraph)
                     }) {
-                        Text("Save", fontFamily = FontFamily.Serif)
+                        Text("Save", fontFamily = GaeguRegular)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Style Lines page using PaperBackground and Gaegu fonts
- Unify Lines & Paragraphs tab, buttons, and dialogs with handwriting fonts
- Use parchment background and Gaegu fonts in line/paragraph editors

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dea5b2228832aa98dd4f2159abada