### PR TITLE
Add swipe-based paragraph editor with poetic line cards

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ParagraphLineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ParagraphLineCard.kt
@@ -1,0 +1,63 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.pages.GaeguRegular
+
+@Composable
+fun ParagraphLineCard(
+    line: Line,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null
+) {
+    val moodColor = when (line.mood.lowercase()) {
+        "calm" -> Color(0xFFB3E5FC)
+        "alert" -> Color(0xFFFFF9C4)
+        "connected" -> Color(0xFFE1BEE7)
+        "alive" -> Color(0xFFC8E6C9)
+        "empty" -> Color(0xFFFFE0B2)
+        "carried" -> Color(0xFFD7CCC8)
+        "searching" -> Color(0xFFDCE775)
+        else -> Color(0xFFFFF8E1)
+    }.copy(alpha = 0.6f)
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = moodColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = line.title,
+                style = MaterialTheme.typography.titleMedium.copy(fontFamily = GaeguBold, color = Color(0xFF3E2723))
+            )
+            Text(
+                text = line.mood,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = GaeguRegular, color = Color(0xFF5D4037))
+            )
+            line.exercises.firstOrNull()?.let { first ->
+                Text(
+                    text = first.name,
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = GaeguRegular, color = Color(0xFF5D4037))
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
@@ -1,0 +1,177 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.ui.components.ParagraphLineCard
+import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.pages.GaeguRegular
+import com.example.mygymapp.viewmodel.LineViewModel
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun ParagraphEditorPageSwipe(
+    initial: Paragraph?,
+    onSave: (Paragraph) -> Unit,
+) {
+    var title by remember { mutableStateOf(initial?.title ?: "") }
+    var mood by remember { mutableStateOf(initial?.mood ?: "") }
+    var tagsText by remember { mutableStateOf(initial?.tags?.joinToString(", ") ?: "") }
+    var note by remember { mutableStateOf(initial?.note ?: "") }
+
+    val lineViewModel: LineViewModel = viewModel()
+    val lines by lineViewModel.lines.collectAsState()
+    val selectedLines = remember {
+        mutableStateListOf<Line?>().apply { repeat(7) { add(null) } }
+    }
+
+    LaunchedEffect(lines) {
+        if (initial != null && selectedLines.all { it == null }) {
+            initial.lineTitles.forEachIndexed { idx, title ->
+                selectedLines[idx] = lines.find { it.title == title }
+            }
+        }
+    }
+
+    val dayNames = listOf("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+    val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
+    var moodExpanded by remember { mutableStateOf(false) }
+    val pagerState = rememberPagerState(pageCount = { 7 })
+    val coroutineScope = rememberCoroutineScope()
+
+    PaperBackground(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+            .imePadding()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+        ) {
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text("Title", fontFamily = GaeguRegular, color = Color.Black) },
+                textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+
+            ExposedDropdownMenuBox(
+                expanded = moodExpanded,
+                onExpandedChange = { moodExpanded = !moodExpanded }
+            ) {
+                OutlinedTextField(
+                    value = mood,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Mood", fontFamily = GaeguRegular, color = Color.Black) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(moodExpanded) },
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth(),
+                    textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black)
+                )
+                ExposedDropdownMenu(
+                    expanded = moodExpanded,
+                    onDismissRequest = { moodExpanded = false }
+                ) {
+                    moods.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option, fontFamily = GaeguRegular, color = Color.Black) },
+                            onClick = {
+                                mood = option
+                                moodExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = tagsText,
+                onValueChange = { tagsText = it },
+                label = { Text("Tags", fontFamily = GaeguRegular, color = Color.Black) },
+                textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = note,
+                onValueChange = { note = it },
+                label = { Text("Note", fontFamily = GaeguRegular, color = Color.Black) },
+                textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            TabRow(selectedTabIndex = pagerState.currentPage) {
+                dayNames.forEachIndexed { index, day ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
+                        text = { Text(day.take(3), fontFamily = GaeguRegular, color = Color.Black) }
+                    )
+                }
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) { page ->
+                LazyColumn {
+                    items(lines) { line ->
+                        val isSelected = selectedLines[page]?.id == line.id
+                        ParagraphLineCard(
+                            line = line,
+                            modifier = Modifier.border(
+                                if (isSelected) BorderStroke(2.dp, Color(0xFF5D4037)) else BorderStroke(0.dp, Color.Transparent)
+                            ),
+                            onClick = { selectedLines[page] = line }
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = {
+                    val tags = tagsText.split(',').map { it.trim() }.filter { it.isNotBlank() }
+                    val lineTitles = selectedLines.map { it?.title ?: "" }
+                    val paragraph = Paragraph(
+                        id = initial?.id ?: System.currentTimeMillis(),
+                        title = title,
+                        mood = mood,
+                        tags = tags,
+                        lineTitles = lineTitles,
+                        note = note
+                    )
+                    onSave(paragraph)
+                },
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text("Save", fontFamily = GaeguRegular, color = Color.Black)
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
@@ -17,7 +17,7 @@ fun ParagraphEditorScreen(
     val templates by paragraphViewModel.templates.collectAsState()
     val initial = paragraphs.find { it.id == editId } ?: templates.find { it.id == editId }
 
-    ParagraphEditorPage(
+    ParagraphEditorPageSwipe(
         initial = initial,
         onSave = { paragraph ->
             if (initial == null || templates.any { it.id == editId }) {
@@ -26,7 +26,6 @@ fun ParagraphEditorScreen(
                 paragraphViewModel.editParagraph(paragraph)
             }
             navController.popBackStack()
-        },
-        onCancel = { navController.popBackStack() }
+        }
     )
 }


### PR DESCRIPTION
## Summary
- introduce `ParagraphLineCard` with Gaegu serif typography, pastel mood colors, and soft shadows to show a line's title, mood, and first exercise
- render `ParagraphLineCard` in `ParagraphEditorPageSwipe` for daily line selection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688df7c4a1b8832aa7cce5f85ed3eaee