### PR TITLE
Add PoeticLineCard component

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticLineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticLineCard.kt
@@ -1,0 +1,73 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.pages.GaeguLight
+
+@Composable
+fun PoeticLineCard(
+    line: Line,
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    onClick: (() -> Unit)? = null
+) {
+    val baseColor = Color(0xFFFFF8E1)
+    val selectedColor = Color(0xFFF0E2C2)
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected) selectedColor else baseColor
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = line.title,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontFamily = GaeguBold,
+                    color = Color(0xFF3E2723)
+                )
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "${line.category} · ${line.muscleGroup}",
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontFamily = GaeguLight,
+                    color = Color(0xFF5D4037)
+                )
+            )
+            Spacer(Modifier.height(2.dp))
+            line.exercises.firstOrNull()?.let { first ->
+                val more = if (line.exercises.size > 1) " ... ➝" else ""
+                Text(
+                    text = first.name + more,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = GaeguLight,
+                        color = Color(0xFF5D4037)
+                    )
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
@@ -1,7 +1,6 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.border
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -12,16 +11,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
-import com.example.mygymapp.ui.components.ParagraphLineCard
 import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.components.PoeticLineCard
 import com.example.mygymapp.ui.pages.GaeguRegular
 import com.example.mygymapp.viewmodel.LineViewModel
 import kotlinx.coroutines.launch
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.ui.Alignment
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -58,25 +56,25 @@ fun ParagraphEditorPageSwipe(
         modifier = Modifier
             .fillMaxSize()
             .systemBarsPadding()
-            .imePadding()
+            .imePadding(),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
         ) {
             OutlinedTextField(
                 value = title,
                 onValueChange = { title = it },
                 label = { Text("Title", fontFamily = GaeguRegular, color = Color.Black) },
                 textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(8.dp))
 
             ExposedDropdownMenuBox(
                 expanded = moodExpanded,
-                onExpandedChange = { moodExpanded = !moodExpanded }
+                onExpandedChange = { moodExpanded = !moodExpanded },
             ) {
                 OutlinedTextField(
                     value = mood,
@@ -87,11 +85,11 @@ fun ParagraphEditorPageSwipe(
                     modifier = Modifier
                         .menuAnchor()
                         .fillMaxWidth(),
-                    textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black)
+                    textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
                 )
                 ExposedDropdownMenu(
                     expanded = moodExpanded,
-                    onDismissRequest = { moodExpanded = false }
+                    onDismissRequest = { moodExpanded = false },
                 ) {
                     moods.forEach { option ->
                         DropdownMenuItem(
@@ -99,7 +97,7 @@ fun ParagraphEditorPageSwipe(
                             onClick = {
                                 mood = option
                                 moodExpanded = false
-                            }
+                            },
                         )
                     }
                 }
@@ -111,7 +109,7 @@ fun ParagraphEditorPageSwipe(
                 onValueChange = { tagsText = it },
                 label = { Text("Tags", fontFamily = GaeguRegular, color = Color.Black) },
                 textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(8.dp))
             OutlinedTextField(
@@ -119,7 +117,7 @@ fun ParagraphEditorPageSwipe(
                 onValueChange = { note = it },
                 label = { Text("Note", fontFamily = GaeguRegular, color = Color.Black) },
                 textStyle = LocalTextStyle.current.copy(fontFamily = GaeguRegular, color = Color.Black),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
 
             Spacer(Modifier.height(16.dp))
@@ -129,7 +127,7 @@ fun ParagraphEditorPageSwipe(
                     Tab(
                         selected = pagerState.currentPage == index,
                         onClick = { coroutineScope.launch { pagerState.animateScrollToPage(index) } },
-                        text = { Text(day.take(3), fontFamily = GaeguRegular, color = Color.Black) }
+                        text = { Text(day.take(3), fontFamily = GaeguRegular, color = Color.Black) },
                     )
                 }
             }
@@ -138,18 +136,110 @@ fun ParagraphEditorPageSwipe(
                 state = pagerState,
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
             ) { page ->
-                LazyColumn {
-                    items(lines) { line ->
-                        val isSelected = selectedLines[page]?.id == line.id
-                        ParagraphLineCard(
-                            line = line,
-                            modifier = Modifier.border(
-                                if (isSelected) BorderStroke(2.dp, Color(0xFF5D4037)) else BorderStroke(0.dp, Color.Transparent)
-                            ),
-                            onClick = { selectedLines[page] = line }
+                var query by remember(page) { mutableStateOf("") }
+                var selectedCategory by remember(page) { mutableStateOf<String?>(null) }
+                var categoryExpanded by remember(page) { mutableStateOf(false) }
+                var showAll by remember(page) { mutableStateOf(false) }
+                val sheetState = rememberModalBottomSheetState()
+
+                val categories = lines.map { it.category }.distinct().sorted()
+                val filteredLines = lines.filter { line ->
+                    line.title.contains(query, ignoreCase = true) &&
+                        (selectedCategory == null || line.category == selectedCategory)
+                }
+                val randomLines = remember(filteredLines) { filteredLines.shuffled().take(3) }
+
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TextField(
+                            value = query,
+                            onValueChange = { query = it },
+                            modifier = Modifier.weight(1f),
+                            placeholder = { Text("Search lines") },
                         )
+                        ExposedDropdownMenuBox(
+                            expanded = categoryExpanded,
+                            onExpandedChange = { categoryExpanded = !categoryExpanded },
+                        ) {
+                            OutlinedTextField(
+                                value = selectedCategory ?: "All",
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text("Category") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = categoryExpanded) },
+                                modifier = Modifier.menuAnchor(),
+                            )
+                            ExposedDropdownMenu(
+                                expanded = categoryExpanded,
+                                onDismissRequest = { categoryExpanded = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("All") },
+                                    onClick = {
+                                        selectedCategory = null
+                                        categoryExpanded = false
+                                    },
+                                )
+                                categories.forEach { cat ->
+                                    DropdownMenuItem(
+                                        text = { Text(cat) },
+                                        onClick = {
+                                            selectedCategory = cat
+                                            categoryExpanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    LazyColumn(
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        items(randomLines) { line ->
+                            val isSelected = selectedLines[page]?.id == line.id
+                            PoeticLineCard(
+                                line = line,
+                                isSelected = isSelected,
+                                onClick = { selectedLines[page] = line },
+                            )
+                        }
+                    }
+
+                    TextButton(
+                        onClick = { showAll = true },
+                        modifier = Modifier.align(Alignment.End),
+                    ) {
+                        Text("Show all lines")
+                    }
+                }
+
+                if (showAll) {
+                    ModalBottomSheet(
+                        onDismissRequest = { showAll = false },
+                        sheetState = sheetState,
+                    ) {
+                        LazyColumn {
+                            items(filteredLines) { line ->
+                                val isSelected = selectedLines[page]?.id == line.id
+                                PoeticLineCard(
+                                    line = line,
+                                    isSelected = isSelected,
+                                    onClick = {
+                                        selectedLines[page] = line
+                                        showAll = false
+                                    },
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -165,11 +255,11 @@ fun ParagraphEditorPageSwipe(
                         mood = mood,
                         tags = tags,
                         lineTitles = lineTitles,
-                        note = note
+                        note = note,
                     )
                     onSave(paragraph)
                 },
-                modifier = Modifier.align(Alignment.End)
+                modifier = Modifier.align(Alignment.End),
             ) {
                 Text("Save", fontFamily = GaeguRegular, color = Color.Black)
             }


### PR DESCRIPTION
## Summary
- add PoeticLineCard composable for simplified line preview
- integrate PoeticLineCard into ParagraphEditorPageSwipe for line selection
- limit daily line list to three random entries with search/filter and a full list modal

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e13e1c5a0832ab48a280e0decbb01