### PR TITLE
Persist paragraphs with Room

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/mygymapp/data/AppDatabase.kt
@@ -9,14 +9,16 @@ import com.example.mygymapp.data.StringListConverter
 import com.example.mygymapp.data.PlanDay
 import com.example.mygymapp.data.ExerciseConverters
 
+
 @Database(
     entities = [
         Plan::class,
         PlanExerciseCrossRef::class,
         Exercise::class,
-        PlanDay::class
+        PlanDay::class,
+        ParagraphEntity::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = false
 )
 @TypeConverters(PlanConverters::class, StringListConverter::class, ExerciseConverters::class)
@@ -24,6 +26,7 @@ abstract class AppDatabase : RoomDatabase() {
 
     abstract fun planDao(): PlanDao
     abstract fun exerciseDao(): ExerciseDao   // <<< sicherstellen, dass es hier steht
+    abstract fun paragraphDao(): ParagraphDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/example/mygymapp/data/ParagraphDao.kt
+++ b/app/src/main/java/com/example/mygymapp/data/ParagraphDao.kt
@@ -1,0 +1,24 @@
+package com.example.mygymapp.data
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ParagraphDao {
+    @Query("SELECT * FROM paragraphs")
+    fun getAll(): Flow<List<ParagraphEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(paragraph: ParagraphEntity): Long
+
+    @Update
+    fun update(paragraph: ParagraphEntity)
+
+    @Delete
+    fun delete(paragraph: ParagraphEntity)
+}

--- a/app/src/main/java/com/example/mygymapp/data/ParagraphEntity.kt
+++ b/app/src/main/java/com/example/mygymapp/data/ParagraphEntity.kt
@@ -1,0 +1,15 @@
+package com.example.mygymapp.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
+import com.example.mygymapp.data.StringListConverter
+
+@Entity(tableName = "paragraphs")
+@TypeConverters(StringListConverter::class)
+data class ParagraphEntity(
+    @PrimaryKey val id: Long,
+    val title: String,
+    val lineTitles: List<String>,
+    val note: String
+)

--- a/app/src/main/java/com/example/mygymapp/data/ParagraphRepository.kt
+++ b/app/src/main/java/com/example/mygymapp/data/ParagraphRepository.kt
@@ -1,24 +1,28 @@
 package com.example.mygymapp.data
 
 import com.example.mygymapp.model.Paragraph
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
-class ParagraphRepository {
-    private val _paragraphs = MutableStateFlow<List<Paragraph>>(emptyList())
-    val paragraphs = _paragraphs
+class ParagraphRepository(private val dao: ParagraphDao) {
+    val paragraphs: Flow<List<Paragraph>> =
+        dao.getAll().map { list -> list.map { it.toModel() } }
 
     fun add(paragraph: Paragraph) {
-        _paragraphs.update { it + paragraph }
+        dao.insert(paragraph.toEntity())
     }
 
     fun edit(paragraph: Paragraph) {
-        _paragraphs.update { list ->
-            list.map { if (it.id == paragraph.id) paragraph else it }
-        }
+        dao.update(paragraph.toEntity())
     }
 
     fun delete(paragraph: Paragraph) {
-        _paragraphs.update { it.filterNot { p -> p.id == paragraph.id } }
+        dao.delete(paragraph.toEntity())
     }
 }
+
+fun Paragraph.toEntity(): ParagraphEntity =
+    ParagraphEntity(id = id, title = title, lineTitles = lineTitles, note = note)
+
+fun ParagraphEntity.toModel(): Paragraph =
+    Paragraph(id = id, title = title, lineTitles = lineTitles, note = note)

--- a/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
@@ -1,22 +1,28 @@
 package com.example.mygymapp.viewmodel
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.mygymapp.data.AppDatabase
 import com.example.mygymapp.data.ParagraphRepository
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.model.PlannedParagraph
 import java.time.LocalDate
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.SharingStarted
 
-class ParagraphViewModel(
-    private val repo: ParagraphRepository = ParagraphRepository()
-) : ViewModel() {
-    private val _paragraphs = MutableStateFlow<List<Paragraph>>(emptyList())
-    val paragraphs: StateFlow<List<Paragraph>> = _paragraphs.asStateFlow()
+class ParagraphViewModel(application: Application) : AndroidViewModel(application) {
+    private val repo: ParagraphRepository =
+        ParagraphRepository(AppDatabase.getDatabase(application).paragraphDao())
+
+    val paragraphs: StateFlow<List<Paragraph>> =
+        repo.paragraphs.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _templates = MutableStateFlow<List<Paragraph>>(emptyList())
     val templates: StateFlow<List<Paragraph>> = _templates.asStateFlow()
@@ -24,15 +30,14 @@ class ParagraphViewModel(
     private val _planned = MutableStateFlow<List<PlannedParagraph>>(emptyList())
     val planned: StateFlow<List<PlannedParagraph>> = _planned.asStateFlow()
 
-    init {
-        viewModelScope.launch {
-            repo.paragraphs.collect { _paragraphs.value = it }
-        }
-    }
+    fun addParagraph(paragraph: Paragraph) =
+        viewModelScope.launch(Dispatchers.IO) { repo.add(paragraph) }
 
-    fun addParagraph(paragraph: Paragraph) = repo.add(paragraph)
-    fun editParagraph(paragraph: Paragraph) = repo.edit(paragraph)
-    fun deleteParagraph(paragraph: Paragraph) = repo.delete(paragraph)
+    fun editParagraph(paragraph: Paragraph) =
+        viewModelScope.launch(Dispatchers.IO) { repo.edit(paragraph) }
+
+    fun deleteParagraph(paragraph: Paragraph) =
+        viewModelScope.launch(Dispatchers.IO) { repo.delete(paragraph) }
 
     fun saveTemplate(paragraph: Paragraph) {
         _templates.update { it + paragraph.copy() }


### PR DESCRIPTION
## Summary
- add `ParagraphEntity` and DAO for Room-based persistence
- refactor repository and view model to load and modify paragraphs through Room
- register new entity/DAO in `AppDatabase` with migration version bump

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3f131344832a89db15b037ea712b