### PR TITLE
Ensure ParagraphEditor returns to Paragraphs tab

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
@@ -29,6 +29,10 @@ fun ParagraphEditorScreen(
                 popUpTo("line_paragraph?tab=0") { inclusive = true }
             }
         },
-        onCancel = { navController.popBackStack() }
+        onCancel = {
+            navController.navigate("line_paragraph?tab=1") {
+                popUpTo("line_paragraph?tab=0") { inclusive = true }
+            }
+        }
     )
 }


### PR DESCRIPTION
## Summary
- Fix ParagraphEditorScreen navigation to always go back to the Paragraphs tab when saving or cancelling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e65e2001c832a859f1b139e4f6b35