### PR TITLE
Ensure ParagraphEditor returns to Paragraphs tab

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
@@ -48,17 +48,16 @@ fun ParagraphEditorPageSwipe(
     onSave: (Paragraph) -> Unit,
     onCancel: () -> Unit,
 ) {
-    var title by remember { mutableStateOf(initial?.title ?: "") }
-    var note by remember { mutableStateOf(initial?.note ?: "") }
+    var title by remember(initial) { mutableStateOf(initial?.title ?: "") }
+    var note by remember(initial) { mutableStateOf(initial?.note ?: "") }
 
     val lineViewModel: LineViewModel = viewModel()
     val lines by lineViewModel.lines.collectAsState()
-    val selectedLines = remember {
-        mutableStateListOf<Line?>().apply { repeat(7) { add(null) } }
-    }
+    val selectedLines = remember { mutableStateListOf<Line?>().apply { repeat(7) { add(null) } } }
 
-    LaunchedEffect(lines) {
-        if (initial != null && selectedLines.all { it == null }) {
+    LaunchedEffect(initial, lines) {
+        selectedLines.indices.forEach { selectedLines[it] = null }
+        if (initial != null) {
             initial.lineTitles.forEachIndexed { idx, title ->
                 selectedLines[idx] = lines.find { it.title == title }
             }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
@@ -14,21 +14,24 @@ fun ParagraphEditorScreen(
     paragraphViewModel: ParagraphViewModel = viewModel()
 ) {
     val paragraphs by paragraphViewModel.paragraphs.collectAsState()
-    val templates by paragraphViewModel.templates.collectAsState()
-    val initial = paragraphs.find { it.id == editId } ?: templates.find { it.id == editId }
+    val initial = paragraphs.find { it.id == editId }
 
     ParagraphEditorPageSwipe(
         initial = initial,
         onSave = { paragraph ->
-            if (initial == null || templates.any { it.id == editId }) {
-                paragraphViewModel.addParagraph(paragraph)
-            } else {
+            if (initial != null) {
                 paragraphViewModel.editParagraph(paragraph)
+            } else {
+                paragraphViewModel.addParagraph(paragraph)
             }
             navController.navigate("line_paragraph?tab=1") {
                 popUpTo("line_paragraph?tab=0") { inclusive = true }
             }
         },
-        onCancel = { navController.popBackStack() }
+        onCancel = {
+            navController.navigate("line_paragraph?tab=1") {
+                popUpTo("line_paragraph?tab=0") { inclusive = true }
+            }
+        }
     )
 }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/ParagraphViewModel.kt
@@ -34,7 +34,17 @@ class ParagraphViewModel(application: Application) : AndroidViewModel(applicatio
         viewModelScope.launch(Dispatchers.IO) { repo.add(paragraph) }
 
     fun editParagraph(paragraph: Paragraph) =
-        viewModelScope.launch(Dispatchers.IO) { repo.edit(paragraph) }
+        viewModelScope.launch(Dispatchers.IO) {
+            repo.edit(paragraph)
+            _templates.update { list ->
+                list.map { if (it.id == paragraph.id) paragraph else it }
+            }
+            _planned.update { list ->
+                list.map {
+                    if (it.paragraph.id == paragraph.id) it.copy(paragraph = paragraph) else it
+                }
+            }
+        }
 
     fun deleteParagraph(paragraph: Paragraph) =
         viewModelScope.launch(Dispatchers.IO) { repo.delete(paragraph) }


### PR DESCRIPTION
## Summary
- Fix ParagraphEditorScreen navigation to always go back to the Paragraphs tab when saving or cancelling
- Prefill paragraph editor fields from existing entries and update paragraphs instead of duplicating

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e65e2001c832a859f1b139e4f6b35