### PR TITLE
Refactor lines UI and remove mood

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Line.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Line.kt
@@ -10,7 +10,6 @@ data class Line(
     val title: String,
     val category: String,
     val muscleGroup: String,
-    val mood: String,
     val exercises: List<Exercise>,
     val supersets: List<Pair<Long, Long>>, // pair of exercise ids forming a superset
     val note: String,

--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -11,129 +11,137 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.R
 import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.pages.GaeguRegular
 
 @Composable
 fun LineCard(
     line: Line,
     onEdit: () -> Unit,
-    onAdd: () -> Unit,
     onArchive: () -> Unit,
+    onRestore: () -> Unit,
+    onUse: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val fade by animateFloatAsState(if (line.isArchived) 0f else 1f, label = "fade")
-    val gaeguRegular = FontFamily(Font(R.font.gaegu_regular))
-    val gaeguBold = FontFamily(Font(R.font.gaegu_bold))
-    val gaeguLight = FontFamily(Font(R.font.gaegu_light))
+    val fade by animateFloatAsState(if (line.isArchived) 0.5f else 1f, label = "fade")
     val textColor = Color(0xFF5D4037)
     val buttonBackground = Color(0xFFFFF8E1)
 
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp)
             .alpha(fade),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = Color.Transparent),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
-        Column(modifier = Modifier.padding(20.dp)) {
-            Text(
-                text = line.title,
-                style = TextStyle(
-                    fontFamily = gaeguBold,
+        Box {
+            Image(
+                painter = painterResource(R.drawable.background_parchment),
+                contentDescription = null,
+                modifier = Modifier.matchParentSize(),
+                contentScale = ContentScale.Crop
+            )
+            Column(
+                modifier = Modifier
+                    .padding(20.dp)
+            ) {
+                Text(
+                    text = line.title,
+                    fontFamily = GaeguBold,
                     fontSize = 24.sp,
                     color = textColor
                 )
-            )
-            Spacer(modifier = Modifier.height(6.dp))
-            Text(
-                text = "${line.category} · ${line.muscleGroup} · ${line.mood}",
-                style = TextStyle(
-                    fontFamily = gaeguRegular,
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "${line.category} · ${line.muscleGroup}",
+                    fontFamily = GaeguRegular,
                     fontSize = 14.sp,
                     color = textColor
                 )
-            )
-            Spacer(modifier = Modifier.height(6.dp))
-            Text(
-                text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
-                style = TextStyle(
-                    fontFamily = gaeguRegular,
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "• ${line.exercises.size} exercises",
+                    fontFamily = GaeguRegular,
                     fontSize = 14.sp,
                     color = textColor
                 )
-            )
-            Column(modifier = Modifier.padding(20.dp)) {
-                Text(
-                    text = line.title,
-                    style = TextStyle(
-                        fontFamily = gaeguBold,
-                        fontSize = 24.sp,
-                        color = textColor
-                    )
-                )
-                Spacer(modifier = Modifier.height(6.dp))
-                Text(
-                    text = "📎 ${line.note}",
-                    style = TextStyle(
-                        fontFamily = gaeguLight,
+                if (line.supersets.isNotEmpty()) {
+                    Text(
+                        text = "• ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
+                        fontFamily = GaeguRegular,
                         fontSize = 14.sp,
                         color = textColor
-                    ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(
-                    onClick = onEdit,
-                    colors = ButtonDefaults.textButtonColors(
-                        containerColor = buttonBackground,
-                        contentColor = textColor
-                    )
-                ) {
-                    Text(
-                        "✏️ Edit",
-                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
                     )
                 }
-                TextButton(
-                    onClick = onAdd,
-                    colors = ButtonDefaults.textButtonColors(
-                        containerColor = buttonBackground,
-                        contentColor = textColor
-                    )
-                ) {
+                if (line.note.isNotBlank()) {
+                    Spacer(Modifier.height(8.dp))
                     Text(
-                        "📥 Add",
-                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
+                        text = "📎 ${line.note}",
+                        fontFamily = GaeguRegular,
+                        fontSize = 14.sp,
+                        fontStyle = FontStyle.Italic,
+                        color = textColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
-                TextButton(
-                    onClick = onArchive,
-                    colors = ButtonDefaults.textButtonColors(
-                        containerColor = buttonBackground,
-                        contentColor = textColor
-                    )
+                Spacer(Modifier.height(12.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        "📦 Archive",
-                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
-                    )
+                    TextButton(
+                        onClick = onEdit,
+                        colors = ButtonDefaults.textButtonColors(
+                            containerColor = buttonBackground,
+                            contentColor = textColor
+                        )
+                    ) {
+                        Text("✏ Edit", fontFamily = GaeguRegular, fontSize = 14.sp)
+                    }
+                    if (line.isArchived) {
+                        TextButton(
+                            onClick = onRestore,
+                            colors = ButtonDefaults.textButtonColors(
+                                containerColor = buttonBackground,
+                                contentColor = textColor
+                            )
+                        ) {
+                            Text("🧷 Restore", fontFamily = GaeguRegular, fontSize = 14.sp)
+                        }
+                    } else {
+                        TextButton(
+                            onClick = onArchive,
+                            colors = ButtonDefaults.textButtonColors(
+                                containerColor = buttonBackground,
+                                contentColor = textColor
+                            )
+                        ) {
+                            Text("🗃 Archive", fontFamily = GaeguRegular, fontSize = 14.sp)
+                        }
+                        TextButton(
+                            onClick = onUse,
+                            colors = ButtonDefaults.textButtonColors(
+                                containerColor = buttonBackground,
+                                contentColor = textColor
+                            )
+                        ) {
+                            Text("🧾 Use in Entry", fontFamily = GaeguRegular, fontSize = 14.sp)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/mygymapp/ui/components/ParagraphLineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ParagraphLineCard.kt
@@ -23,34 +23,19 @@ fun ParagraphLineCard(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val moodColor = when (line.mood.lowercase()) {
-        "calm" -> Color(0xFFB3E5FC)
-        "alert" -> Color(0xFFFFF9C4)
-        "connected" -> Color(0xFFE1BEE7)
-        "alive" -> Color(0xFFC8E6C9)
-        "empty" -> Color(0xFFFFE0B2)
-        "carried" -> Color(0xFFD7CCC8)
-        "searching" -> Color(0xFFDCE775)
-        else -> Color(0xFFFFF8E1)
-    }.copy(alpha = 0.6f)
-
     Card(
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
             .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
         shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = moodColor),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(
                 text = line.title,
                 style = MaterialTheme.typography.titleMedium.copy(fontFamily = GaeguBold, color = Color(0xFF3E2723))
-            )
-            Text(
-                text = line.mood,
-                style = MaterialTheme.typography.bodySmall.copy(fontFamily = GaeguRegular, color = Color(0xFF5D4037))
             )
             line.exercises.firstOrNull()?.let { first ->
                 Text(

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -39,7 +39,6 @@ fun LineEditorPage(
     var title by remember { mutableStateOf(initial?.title ?: "") }
     var category by remember { mutableStateOf(initial?.category ?: "") }
     var muscleGroup by remember { mutableStateOf(initial?.muscleGroup ?: "") }
-    var mood by remember { mutableStateOf(initial?.mood ?: "") }
     var note by remember { mutableStateOf(initial?.note ?: "") }
 
     var search by remember { mutableStateOf("") }
@@ -99,12 +98,6 @@ fun LineEditorPage(
                 value = muscleGroup,
                 onValueChange = { muscleGroup = it },
                 label = { Text("Muscle Group", fontFamily = GaeguRegular, color = Color.Black) },
-                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
-            )
-            OutlinedTextField(
-                value = mood,
-                onValueChange = { mood = it },
-                label = { Text("Mood", fontFamily = GaeguRegular, color = Color.Black) },
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
             OutlinedTextField(
@@ -200,7 +193,6 @@ fun LineEditorPage(
                         title = title,
                         category = category,
                         muscleGroup = muscleGroup,
-                        mood = mood,
                         exercises = exerciseList.toList(),
                         supersets = supersets.toList(),
                         note = note,

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -14,13 +14,11 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.model.PlannedParagraph
-import com.example.mygymapp.ui.pages.LinesPage
 import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.pages.ParagraphsPage
 import java.time.Instant
@@ -69,17 +67,14 @@ fun LineParagraphPage(
             Crossfade(targetState = selectedTab, label = "tab") { tab ->
                 when (tab) {
                     0 -> LinesPage(
-                        lines = lines.filter { !it.isArchived },
-                        onAdd = {
-                            editingLine = null
-                            showLineEditor = true
-                        },
+                        lines = lines,
                         onEdit = {
                             editingLine = it
                             showLineEditor = true
                         },
                         onArchive = { lineViewModel.archive(it.id) },
-                        onManageExercises = { navController.navigate("exercise_management") }
+                        onRestore = { lineViewModel.unarchive(it.id) },
+                        onUse = { }
                     )
                     else -> ParagraphsPage(
                         paragraphs = paragraphs,
@@ -122,7 +117,7 @@ fun LineParagraphPage(
                 shape = MaterialTheme.shapes.medium
             ) {
                 Text(
-                    text = if (selectedTab == 0) "➕ Write a new line" else "➕ Add Paragraph",
+                    text = if (selectedTab == 0) "➕ Compose a new line" else "➕ Add Paragraph",
                     fontFamily = GaeguRegular,
                     color = Color.Black
                 )

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
@@ -1,56 +1,91 @@
 package com.example.mygymapp.ui.pages
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.ui.components.LineCard
 import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.pages.GaeguRegular
 
 @Composable
 fun LinesPage(
     lines: List<Line>,
-    onAdd: () -> Unit,
     onEdit: (Line) -> Unit,
     onArchive: (Line) -> Unit,
-    onManageExercises: () -> Unit,
+    onRestore: (Line) -> Unit,
+    onUse: (Line) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val (showArchived, setShowArchived) = remember { mutableStateOf(false) }
+    val categories = listOf("All", "Push", "Pull", "Core", "Cardio", "Recovery")
+    val (selectedCategory, setSelectedCategory) = remember { mutableStateOf("All") }
+
     PaperBackground(modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {
-            TextButton(
-                onClick = onAdd,
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                listOf("Active", "Archived").forEach { label ->
+                    val selected = showArchived == (label == "Archived")
+                    Text(
+                        text = label,
+                        fontFamily = GaeguRegular,
+                        color = Color.Black.copy(alpha = if (selected) 1f else 0.5f),
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .clickable { setShowArchived(label == "Archived") }
+                    )
+                }
+            }
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 8.dp)
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Text("\u2795 Write a new line", fontFamily = GaeguRegular, color = Color.Black)
+                categories.forEach { cat ->
+                    FilterChip(
+                        selected = selectedCategory == cat,
+                        onClick = { setSelectedCategory(cat) },
+                        label = { Text(cat, fontFamily = GaeguRegular, color = Color.Black) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            containerColor = Color(0xFFFFF8E1),
+                            selectedContainerColor = Color(0xFFE0D4B7)
+                        )
+                    )
+                }
             }
-            TextButton(
-                onClick = onManageExercises,
-                modifier = Modifier.align(Alignment.End)
-            ) {
-                Text("\u2699\uFE0F Manage Exercises", fontFamily = GaeguRegular, color = Color.Black)
-            }
+            val filtered = lines
+                .filter { if (showArchived) it.isArchived else !it.isArchived }
+                .filter { selectedCategory == "All" || it.category == selectedCategory }
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                items(lines) { line ->
+                items(filtered) { line ->
                     LineCard(
                         line = line,
                         onEdit = { onEdit(line) },
-                        onAdd = { onAdd() },
-                        onArchive = { onArchive(line) }
+                        onArchive = { onArchive(line) },
+                        onRestore = { onRestore(line) },
+                        onUse = { onUse(line) }
                     )
                 }
             }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/LineViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/LineViewModel.kt
@@ -16,7 +16,6 @@ class LineViewModel : ViewModel() {
                 title = "Silent Force",
                 category = "Push",
                 muscleGroup = "Core",
-                mood = "balanced",
                 exercises = emptyList(),
                 supersets = emptyList(),
                 note = "Felt steady and grounded throughout."
@@ -28,7 +27,6 @@ class LineViewModel : ViewModel() {
                 title = "Night Owl Session",
                 category = "Pull",
                 muscleGroup = "Back",
-                mood = "alert",
                 exercises = emptyList(),
                 supersets = listOf(1L to 2L),
                 note = "Late session with high focus."


### PR DESCRIPTION
## Summary
- redesign LineCard with parchment background, bullet details, and edit/archive/use buttons
- add archive toggle and category chips to LinesPage
- drop mood from line model and editor

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e846e9390832ab4110b66a769a5f8