### PR TITLE
Redesign line editor and remove mood selection

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
@@ -2,16 +2,11 @@
 package com.example.mygymapp.ui.pages
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.background
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -25,21 +20,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.example.mygymapp.ui.components.EntryHeader
 import androidx.compose.foundation.Image
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.layout.ContentScale
 import com.example.mygymapp.R
 import com.example.mygymapp.ui.theme.handwritingText
-import androidx.compose.ui.draw.clip
 import java.time.LocalDate
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
 
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -50,8 +41,6 @@ import androidx.compose.foundation.layout.size
     ) {
         val today = LocalDate.now()
 
-        var mood by remember { mutableStateOf<String?>(null) }
-        val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
         var story by remember { mutableStateOf("") }
 
             Box(modifier = Modifier.fillMaxSize()) {
@@ -74,46 +63,6 @@ import androidx.compose.foundation.layout.size
                         date = today
                     )
 
-                        val emotionColors = listOf(
-                            Color(0xFFFFCDD2),
-                    Color(0xFFBBDEFB),
-                    Color(0xFFC8E6C9),
-                    Color(0xFFFFF9C4),
-                    Color(0xFFD7CCC8),
-                    Color(0xFFD1C4E9),
-                    Color(0xFFFFE0B2)
-                    )
-
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                            moods.forEachIndexed { index, option ->
-                                val selected = mood == option
-                                Box(
-                                    modifier = Modifier
-                                        .size(48.dp)
-                                        .clip(CircleShape)
-                                        .background(emotionColors[index % emotionColors.size])
-                                        .border(
-                                            width = if (selected) 3.dp else 1.dp,
-                                            color = if (selected) Color.Black else Color.DarkGray,
-                                            shape = CircleShape
-                                        )
-                                        .clickable { mood = option },
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(
-                                        text = option.take(1).uppercase(),
-                                        color = Color.Black,
-                                        fontFamily = FontFamily.Serif,
-                                        fontSize = 14.sp
-                                    )
-                                }
-                            }
-                        }
-
                         Text(
                             text = "Today: Push · 3 movements · 34 minutes",
                             style = MaterialTheme.typography.bodyMedium.copy(color = Color.DarkGray),
@@ -134,7 +83,6 @@ import androidx.compose.foundation.layout.size
 
                         Button(
                             onClick = {
-                                mood = null
                                 story = ""
                                 onFinished()
                             },

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.mygymapp.viewmodel.ExerciseViewModel
 import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.components.LineCard
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.background
@@ -85,25 +86,29 @@ fun LineEditorPage(
             OutlinedTextField(
                 value = title,
                 onValueChange = { title = it },
-                label = { Text("Title", fontFamily = GaeguRegular, color = Color.Black) },
-                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
+                placeholder = { Text("What would you call this Line?", fontFamily = GaeguRegular, color = Color.Gray) },
+                modifier = Modifier.fillMaxWidth(),
+                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 24.sp, color = Color.Black)
             )
             OutlinedTextField(
                 value = category,
                 onValueChange = { category = it },
-                label = { Text("Category", fontFamily = GaeguRegular, color = Color.Black) },
+                placeholder = { Text("Category", fontFamily = GaeguRegular, color = Color.Gray) },
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
             OutlinedTextField(
                 value = muscleGroup,
                 onValueChange = { muscleGroup = it },
-                label = { Text("Muscle Group", fontFamily = GaeguRegular, color = Color.Black) },
+                placeholder = { Text("Muscle Group", fontFamily = GaeguRegular, color = Color.Gray) },
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
             OutlinedTextField(
                 value = note,
                 onValueChange = { note = it },
-                label = { Text("Note", fontFamily = GaeguRegular, color = Color.Black) },
+                placeholder = { Text("Anything else you'd like to remember?", fontFamily = GaeguRegular, color = Color.Gray) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
 
@@ -138,14 +143,14 @@ fun LineEditorPage(
                         TextButton(onClick = {
                             selectedExerciseIndex = index
                             showExerciseEditor = true
-                        }) { Text("Edit", fontFamily = GaeguRegular, color = Color.Black) }
-                        TextButton(onClick = { exerciseList.removeAt(index) }) { Text("Remove", fontFamily = GaeguRegular, color = Color.Black) }
+                        }) { Text("✏ Edit", fontFamily = GaeguRegular, color = Color.Black) }
+                        TextButton(onClick = { exerciseList.removeAt(index) }) { Text("🗑 Remove", fontFamily = GaeguRegular, color = Color.Black) }
                     }
                 }
             }
             Button(onClick = {
                 showExercisePicker = true
-            }) { Text("➕ Add movement", fontFamily = GaeguRegular, color = Color.Black) }
+            }) { Text("➕ Add a movement", fontFamily = GaeguRegular, color = Color.Black) }
 
             Text(
                 "Supersets",
@@ -170,7 +175,7 @@ fun LineEditorPage(
                                 supersetSelection.clear()
                                 supersetMode = false
                             }
-                        }) { Text("Group selected", fontFamily = GaeguRegular, color = Color.Black) }
+                        }) { Text("Group into superset", fontFamily = GaeguRegular, color = Color.Black) }
                         TextButton(onClick = { supersetMode = false; supersetSelection.clear() }) { Text("Cancel", fontFamily = GaeguRegular, color = Color.Black) }
                     }
                 } else {
@@ -178,6 +183,29 @@ fun LineEditorPage(
                 }
             }
 
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "Preview this line",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = GaeguBold,
+                color = Color.Black
+            )
+            LineCard(
+                line = Line(
+                    id = initial?.id ?: 0L,
+                    title = title.ifBlank { "Untitled" },
+                    category = category,
+                    muscleGroup = muscleGroup,
+                    exercises = exerciseList.toList(),
+                    supersets = supersets.toList(),
+                    note = note,
+                    isArchived = false
+                ),
+                onEdit = {},
+                onArchive = {},
+                onRestore = {},
+                onUse = {}
+            )
             Spacer(Modifier.height(16.dp))
             Row(
                 horizontalArrangement = Arrangement.End,
@@ -200,7 +228,7 @@ fun LineEditorPage(
                     )
                     onSave(newLine)
                 }) {
-                    Text("Save", fontFamily = GaeguRegular, color = Color.Black)
+                    Text("💾 Save this line", fontFamily = GaeguRegular, color = Color.Black)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Refresh LineEditorPage with placeholder-based inputs and Gaegu fonts
- Add exercise preview card and streamlined superset workflow
- Drop obsolete mood selection from EntryPage

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e87325a54832ab7b03ccfe43db459