### PR TITLE
Redesign line editor and remove mood selection

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
@@ -2,16 +2,11 @@
 package com.example.mygymapp.ui.pages
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.background
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -25,21 +20,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.example.mygymapp.ui.components.EntryHeader
 import androidx.compose.foundation.Image
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.layout.ContentScale
 import com.example.mygymapp.R
 import com.example.mygymapp.ui.theme.handwritingText
-import androidx.compose.ui.draw.clip
 import java.time.LocalDate
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
 
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -50,8 +41,6 @@ import androidx.compose.foundation.layout.size
     ) {
         val today = LocalDate.now()
 
-        var mood by remember { mutableStateOf<String?>(null) }
-        val moods = listOf("calm", "alert", "connected", "alive", "empty", "carried", "searching")
         var story by remember { mutableStateOf("") }
 
             Box(modifier = Modifier.fillMaxSize()) {
@@ -74,46 +63,6 @@ import androidx.compose.foundation.layout.size
                         date = today
                     )
 
-                        val emotionColors = listOf(
-                            Color(0xFFFFCDD2),
-                    Color(0xFFBBDEFB),
-                    Color(0xFFC8E6C9),
-                    Color(0xFFFFF9C4),
-                    Color(0xFFD7CCC8),
-                    Color(0xFFD1C4E9),
-                    Color(0xFFFFE0B2)
-                    )
-
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                            moods.forEachIndexed { index, option ->
-                                val selected = mood == option
-                                Box(
-                                    modifier = Modifier
-                                        .size(48.dp)
-                                        .clip(CircleShape)
-                                        .background(emotionColors[index % emotionColors.size])
-                                        .border(
-                                            width = if (selected) 3.dp else 1.dp,
-                                            color = if (selected) Color.Black else Color.DarkGray,
-                                            shape = CircleShape
-                                        )
-                                        .clickable { mood = option },
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(
-                                        text = option.take(1).uppercase(),
-                                        color = Color.Black,
-                                        fontFamily = FontFamily.Serif,
-                                        fontSize = 14.sp
-                                    )
-                                }
-                            }
-                        }
-
                         Text(
                             text = "Today: Push · 3 movements · 34 minutes",
                             style = MaterialTheme.typography.bodyMedium.copy(color = Color.DarkGray),
@@ -134,7 +83,6 @@ import androidx.compose.foundation.layout.size
 
                         Button(
                             onClick = {
-                                mood = null
                                 story = ""
                                 onFinished()
                             },

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -1,35 +1,35 @@
 package com.example.mygymapp.ui.pages
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mygymapp.model.Line
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.burnoutcrew.reorderable.*
 import com.example.mygymapp.model.Exercise
 import com.example.mygymapp.model.ExerciseCategory
-import com.example.mygymapp.model.MuscleGroup
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.mygymapp.viewmodel.ExerciseViewModel
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.components.LineCard
 import com.example.mygymapp.ui.components.PaperBackground
-import androidx.compose.foundation.ExperimentalFoundationApi
+import com.example.mygymapp.viewmodel.ExerciseViewModel
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.background
 
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun LineEditorPage(
     initial: Line? = null,
@@ -41,29 +41,16 @@ fun LineEditorPage(
     var muscleGroup by remember { mutableStateOf(initial?.muscleGroup ?: "") }
     var note by remember { mutableStateOf(initial?.note ?: "") }
 
-    var search by remember { mutableStateOf("") }
-    var categoryFilter by remember { mutableStateOf<ExerciseCategory?>(null) }
-    var muscleFilter by remember { mutableStateOf<MuscleGroup?>(null) }
-    var favoritesOnly by remember { mutableStateOf(false) }
-
-    var supersetMode by remember { mutableStateOf(false) }
     val supersetSelection = remember { mutableStateListOf<Long>() }
+    val exerciseList = remember { mutableStateListOf<Exercise>().apply { addAll(initial?.exercises ?: emptyList()) } }
+    val supersets = remember { mutableStateListOf<Pair<Long, Long>>().apply { addAll(initial?.supersets ?: emptyList()) } }
 
-    var configExercise by remember { mutableStateOf<com.example.mygymapp.data.Exercise?>(null) }
-    var showConfigSheet by remember { mutableStateOf(false) }
-
-    val exerciseList = remember {
-        mutableStateListOf<Exercise>().apply { addAll(initial?.exercises ?: emptyList()) }
-    }
-    val supersets = remember {
-        mutableStateListOf<Pair<Long, Long>>().apply { addAll(initial?.supersets ?: emptyList()) }
-    }
-    var showExerciseEditor by remember { mutableStateOf(false) }
-    var selectedExerciseIndex by remember { mutableStateOf<Int?>(null) }
     val vm: ExerciseViewModel = viewModel()
     val allExercises by vm.allExercises.observeAsState(emptyList())
-    var showExercisePicker by remember { mutableStateOf(false) }
-    var filtersVisible by remember { mutableStateOf(false) }
+
+    val reorderState = rememberReorderableLazyListState(onMove = { from, to ->
+        exerciseList.add(to.index, exerciseList.removeAt(from.index))
+    })
 
     PaperBackground(
         modifier = Modifier
@@ -85,25 +72,29 @@ fun LineEditorPage(
             OutlinedTextField(
                 value = title,
                 onValueChange = { title = it },
-                label = { Text("Title", fontFamily = GaeguRegular, color = Color.Black) },
-                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
+                placeholder = { Text("What would you call this Line?", fontFamily = GaeguRegular, color = Color.Gray) },
+                modifier = Modifier.fillMaxWidth(),
+                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 24.sp, color = Color.Black)
             )
             OutlinedTextField(
                 value = category,
                 onValueChange = { category = it },
-                label = { Text("Category", fontFamily = GaeguRegular, color = Color.Black) },
+                placeholder = { Text("Category", fontFamily = GaeguRegular, color = Color.Gray) },
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
             OutlinedTextField(
                 value = muscleGroup,
                 onValueChange = { muscleGroup = it },
-                label = { Text("Muscle Group", fontFamily = GaeguRegular, color = Color.Black) },
+                placeholder = { Text("Muscle Group", fontFamily = GaeguRegular, color = Color.Gray) },
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
             OutlinedTextField(
                 value = note,
                 onValueChange = { note = it },
-                label = { Text("Note", fontFamily = GaeguRegular, color = Color.Black) },
+                placeholder = { Text("Anything else you'd like to remember?", fontFamily = GaeguRegular, color = Color.Gray) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
                 textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp, color = Color.Black)
             )
 
@@ -113,71 +104,143 @@ fun LineEditorPage(
                 fontFamily = GaeguBold,
                 color = Color.Black
             )
-            exerciseList.forEachIndexed { index, exercise ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(enabled = supersetMode) {
-                            if (supersetSelection.contains(exercise.id)) supersetSelection.remove(exercise.id)
-                            else supersetSelection.add(exercise.id)
+            LazyColumn(
+                state = reorderState.listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .reorderable(reorderState)
+                    .detectReorderAfterLongPress(reorderState)
+            ) {
+                itemsIndexed(exerciseList, key = { _, ex -> ex.id }) { index, exercise ->
+                    ReorderableItem(reorderState, key = exercise.id) { _ ->
+                        val bg = if (supersetSelection.contains(exercise.id)) Color(0xFFD9CEB2) else Color.Transparent
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(bg, RoundedCornerShape(12.dp))
+                                .padding(8.dp)
+                                .clickable {
+                                    if (supersetSelection.contains(exercise.id)) supersetSelection.remove(exercise.id)
+                                    else if (supersetSelection.size < 2) supersetSelection.add(exercise.id)
+                                },
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(exercise.name, modifier = Modifier.weight(1f), fontFamily = GaeguRegular, color = Color.Black)
+                            var setsText by remember(exercise.id) { mutableStateOf(exercise.sets.toString()) }
+                            var repsText by remember(exercise.id) { mutableStateOf(exercise.repsOrDuration) }
+                            BasicTextField(
+                                value = setsText,
+                                onValueChange = {
+                                    setsText = it
+                                    exerciseList[index] = exercise.copy(sets = it.toIntOrNull() ?: exercise.sets)
+                                },
+                                modifier = Modifier.width(40.dp),
+                                textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black),
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                            )
+                            Text(" × ", fontFamily = GaeguRegular, color = Color.Black)
+                            BasicTextField(
+                                value = repsText,
+                                onValueChange = {
+                                    repsText = it
+                                    exerciseList[index] = exercise.copy(repsOrDuration = it)
+                                },
+                                modifier = Modifier.width(60.dp),
+                                textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black)
+                            )
+                            TextButton(onClick = { exerciseList.removeAt(index) }) {
+                                Text("🗑", fontFamily = GaeguRegular, color = Color.Black)
+                            }
                         }
-                        .background(
-                            if (supersetSelection.contains(exercise.id) && supersetMode) Color(0xFFD9CEB2) else Color.Transparent,
-                            RoundedCornerShape(12.dp)
-                        )
-                        .padding(8.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        "${exercise.name} – ${exercise.sets}×${exercise.repsOrDuration}",
-                        fontFamily = GaeguRegular,
-                        color = Color.Black
-                    )
-                    Row {
-                        TextButton(onClick = {
-                            selectedExerciseIndex = index
-                            showExerciseEditor = true
-                        }) { Text("Edit", fontFamily = GaeguRegular, color = Color.Black) }
-                        TextButton(onClick = { exerciseList.removeAt(index) }) { Text("Remove", fontFamily = GaeguRegular, color = Color.Black) }
                     }
                 }
             }
-            Button(onClick = {
-                showExercisePicker = true
-            }) { Text("➕ Add movement", fontFamily = GaeguRegular, color = Color.Black) }
+            if (supersetSelection.size == 2) {
+                Button(onClick = {
+                    supersets.add(supersetSelection[0] to supersetSelection[1])
+                    supersetSelection.clear()
+                }) { Text("🔗 Create Superset", fontFamily = GaeguRegular, color = Color.Black) }
+            }
+            if (supersets.isNotEmpty()) {
+                Text(
+                    "Supersets",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = GaeguBold,
+                    color = Color.Black
+                )
+                supersets.forEach { pair ->
+                    val exA = exerciseList.find { it.id == pair.first }
+                    val exB = exerciseList.find { it.id == pair.second }
+                    if (exA != null && exB != null) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
+                                .combinedClickable(onLongClick = { supersets.remove(pair) }) {},
+                            colors = CardDefaults.cardColors(containerColor = Color(0xFFF5F5DC))
+                        ) {
+                            Column(Modifier.padding(8.dp)) {
+                                Text("• ${exA.name}   [${exA.sets}] × [${exA.repsOrDuration}]", fontFamily = GaeguRegular, color = Color.Black)
+                                Text("• ${exB.name}   [${exB.sets}] × [${exB.repsOrDuration}]", fontFamily = GaeguRegular, color = Color.Black)
+                            }
+                        }
+                    }
+                }
+            }
 
             Text(
-                "Supersets",
+                "Add a movement",
                 style = MaterialTheme.typography.titleMedium,
                 fontFamily = GaeguBold,
                 color = Color.Black
             )
-            supersets.forEachIndexed { index, pair ->
-                val nameA = exerciseList.find { it.id == pair.first }?.name ?: "?"
-                val nameB = exerciseList.find { it.id == pair.second }?.name ?: "?"
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("$nameA + $nameB", fontFamily = GaeguRegular, color = Color.Black)
-                    TextButton(onClick = { supersets.removeAt(index) }) { Text("Remove", fontFamily = GaeguRegular, color = Color.Black) }
-                }
-            }
-            if (exerciseList.size >= 2) {
-                if (supersetMode) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Button(onClick = {
-                            if (supersetSelection.size == 2) {
-                                supersets.add(supersetSelection[0] to supersetSelection[1])
-                                supersetSelection.clear()
-                                supersetMode = false
-                            }
-                        }) { Text("Group selected", fontFamily = GaeguRegular, color = Color.Black) }
-                        TextButton(onClick = { supersetMode = false; supersetSelection.clear() }) { Text("Cancel", fontFamily = GaeguRegular, color = Color.Black) }
+            LazyColumn {
+                items(allExercises) { ex ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(ex.name, modifier = Modifier.weight(1f), fontFamily = GaeguRegular, color = Color.Black)
+                        TextButton(onClick = {
+                            val defaultReps = if (ex.category == ExerciseCategory.Cardio) "30s" else "12"
+                            exerciseList.add(
+                                Exercise(
+                                    id = System.currentTimeMillis(),
+                                    name = ex.name,
+                                    sets = 3,
+                                    repsOrDuration = defaultReps
+                                )
+                            )
+                        }) { Text("➕", fontFamily = GaeguRegular, color = Color.Black) }
                     }
-                } else {
-                    TextButton(onClick = { supersetMode = true }) { Text("Add a superset", fontFamily = GaeguRegular, color = Color.Black) }
                 }
             }
 
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "Preview this line",
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = GaeguBold,
+                color = Color.Black
+            )
+            LineCard(
+                line = Line(
+                    id = initial?.id ?: 0L,
+                    title = title.ifBlank { "Untitled" },
+                    category = category,
+                    muscleGroup = muscleGroup,
+                    exercises = exerciseList.toList(),
+                    supersets = supersets.toList(),
+                    note = note,
+                    isArchived = false
+                ),
+                onEdit = {},
+                onArchive = {},
+                onRestore = {},
+                onUse = {}
+            )
             Spacer(Modifier.height(16.dp))
             Row(
                 horizontalArrangement = Arrangement.End,
@@ -200,197 +263,9 @@ fun LineEditorPage(
                     )
                     onSave(newLine)
                 }) {
-                    Text("Save", fontFamily = GaeguRegular, color = Color.Black)
-                }
-            }
-        }
-    }
-
-    if (showExerciseEditor) {
-        var name by remember { mutableStateOf("") }
-        var sets by remember { mutableStateOf("3") }
-        var reps by remember { mutableStateOf("12") }
-        var prGoal by remember { mutableStateOf("") }
-        var exNote by remember { mutableStateOf("") }
-
-        LaunchedEffect(showExerciseEditor) {
-            if (showExerciseEditor) {
-                selectedExerciseIndex?.let { idx ->
-                    val ex = exerciseList[idx]
-                    name = ex.name
-                    sets = ex.sets.toString()
-                    reps = ex.repsOrDuration
-                    prGoal = ex.prGoal?.toString() ?: ""
-                    exNote = ex.note
-                }
-            }
-        }
-
-        AlertDialog(
-            onDismissRequest = { showExerciseEditor = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    val new = Exercise(
-                        id = System.currentTimeMillis(),
-                        name = name,
-                        sets = sets.toIntOrNull() ?: 3,
-                        repsOrDuration = reps,
-                        prGoal = prGoal.toIntOrNull(),
-                        note = exNote
-                    )
-                    if (selectedExerciseIndex != null) {
-                        exerciseList[selectedExerciseIndex!!] = new
-                    } else {
-                        exerciseList.add(new)
-                    }
-                    showExerciseEditor = false
-                }) { Text("Save", fontFamily = GaeguRegular, color = Color.Black) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showExerciseEditor = false }) { Text("Cancel", fontFamily = GaeguRegular, color = Color.Black) }
-            },
-            title = { Text("Exercise", fontFamily = GaeguRegular, color = Color.Black) },
-            text = {
-                Column {
-                    OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Name", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                    OutlinedTextField(value = sets, onValueChange = { sets = it }, label = { Text("How many sets?", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                    OutlinedTextField(value = reps, onValueChange = { reps = it }, label = { Text("How many times will you move?", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                    OutlinedTextField(value = prGoal, onValueChange = { prGoal = it }, label = { Text("Do you feel a personal challenge?", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                    OutlinedTextField(value = exNote, onValueChange = { exNote = it }, label = { Text("Notes", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                }
-            }
-        )
-    }
-
-    if (showExercisePicker) {
-        val filtered = allExercises.filter { ex ->
-            (search.isBlank() || ex.name.contains(search, ignoreCase = true)) &&
-                    (categoryFilter == null || ex.category == categoryFilter) &&
-                    (muscleFilter == null || ex.muscleGroup == muscleFilter) &&
-                    (!favoritesOnly || ex.isFavorite)
-        }
-        ModalBottomSheet(onDismissRequest = { showExercisePicker = false }) {
-            Column(Modifier
-                .fillMaxHeight(0.9f)
-                .padding(16.dp)) {
-                Text(
-                    "Choose a movement that resonates with today.",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontFamily = GaeguBold,
-                    color = Color.Black
-                )
-                Spacer(Modifier.height(8.dp))
-                TextField(
-                    value = search,
-                    onValueChange = { search = it },
-                    placeholder = { Text("Search gently…", fontFamily = GaeguLight) },
-                    modifier = Modifier.fillMaxWidth(),
-                    textStyle = TextStyle(fontFamily = GaeguRegular)
-                )
-                Spacer(Modifier.height(8.dp))
-                TextButton(onClick = { filtersVisible = !filtersVisible }) {
-                    Text(if (filtersVisible) "Hide filters" else "Show filters", fontFamily = GaeguRegular, color = Color.Black)
-                }
-                if (filtersVisible) {
-                    Spacer(Modifier.height(8.dp))
-                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        AssistChip(onClick = { categoryFilter = null }, label = { Text("All") })
-                        ExerciseCategory.values().forEach { cat ->
-                            AssistChip(
-                                onClick = { categoryFilter = cat },
-                                label = { Text(cat.display) }
-                            )
-                        }
-                    }
-                    Spacer(Modifier.height(8.dp))
-                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        AssistChip(onClick = { muscleFilter = null }, label = { Text("All") })
-                        MuscleGroup.values().forEach { m ->
-                            AssistChip(
-                                onClick = { muscleFilter = m },
-                                label = { Text(m.display) }
-                            )
-                        }
-                    }
-                    Spacer(Modifier.height(8.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        IconButton(onClick = { favoritesOnly = !favoritesOnly }) {
-                            Icon(
-                                imageVector = if (favoritesOnly) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                                contentDescription = null
-                            )
-                        }
-                        Text("Favorites", fontFamily = GaeguRegular, color = Color.Black)
-                    }
-                }
-                Spacer(Modifier.height(8.dp))
-                LazyColumn(modifier = Modifier.weight(1f)) {
-                    items(filtered) { ex ->
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp)
-                                .clickable {
-                                    configExercise = ex
-                                    showExercisePicker = false
-                                    showConfigSheet = true
-                                },
-                            shape = RoundedCornerShape(12.dp),
-                            colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1))
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Text(ex.name, modifier = Modifier.weight(1f), fontFamily = GaeguRegular, color = Color.Black)
-                                if (ex.isFavorite) Icon(Icons.Filled.Star, contentDescription = null)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if (showConfigSheet && configExercise != null) {
-        val base = configExercise!!
-        var setsText by remember { mutableStateOf("3") }
-        var repsText by remember { mutableStateOf("12") }
-        var prText by remember { mutableStateOf("") }
-        var noteText by remember { mutableStateOf("") }
-
-        ModalBottomSheet(onDismissRequest = { showConfigSheet = false }) {
-            Column(Modifier.padding(16.dp)) {
-                Text(base.name, style = MaterialTheme.typography.titleMedium, fontFamily = GaeguRegular, color = Color.Black)
-                Spacer(Modifier.height(8.dp))
-                if (base.description.isNotBlank()) {
-                    Text(base.description, style = MaterialTheme.typography.bodySmall, fontFamily = GaeguRegular, color = Color.Black)
-                    Spacer(Modifier.height(8.dp))
-                }
-                OutlinedTextField(value = setsText, onValueChange = { setsText = it }, label = { Text("How many sets?", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                OutlinedTextField(value = repsText, onValueChange = { repsText = it }, label = { Text("How many times will you move?", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                OutlinedTextField(value = prText, onValueChange = { prText = it }, label = { Text("Do you feel a personal challenge?", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                OutlinedTextField(value = noteText, onValueChange = { noteText = it }, label = { Text("Notes", fontFamily = GaeguRegular, color = Color.Black) }, textStyle = TextStyle(fontFamily = GaeguRegular, color = Color.Black))
-                Spacer(Modifier.height(8.dp))
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                    TextButton(onClick = { showConfigSheet = false }) { Text("Cancel", fontFamily = GaeguRegular, color = Color.Black) }
-                    Spacer(Modifier.width(8.dp))
-                    Button(onClick = {
-                        exerciseList.add(
-                            Exercise(
-                                id = System.currentTimeMillis(),
-                                name = base.name,
-                                sets = setsText.toIntOrNull() ?: 3,
-                                repsOrDuration = repsText,
-                                prGoal = prText.toIntOrNull(),
-                                note = noteText
-                            )
-                        )
-                        showConfigSheet = false
-                    }) { Text("Add to Line", fontFamily = GaeguRegular, color = Color.Black) }
+                    Text("💾 Save this line", fontFamily = GaeguRegular, color = Color.Black)
                 }
             }
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- Refresh LineEditorPage with inline exercise entry and reorderable list
- Add superset linking cards and streamlined movement selection
- Drop obsolete mood selection from EntryPage

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e87325a54832ab7b03ccfe43db459