### PR TITLE
Refactor journal state and add poetic UI components

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Mood.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Mood.kt
@@ -1,0 +1,11 @@
+package com.example.mygymapp.model
+
+/** Simple mood indicator for an entry. */
+enum class Mood {
+    HAPPY,
+    NEUTRAL,
+    SAD,
+    ENERGETIC,
+    TIRED
+}
+

--- a/app/src/main/java/com/example/mygymapp/store/JournalStore.kt
+++ b/app/src/main/java/com/example/mygymapp/store/JournalStore.kt
@@ -2,13 +2,15 @@ package com.example.mygymapp.store
 
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import com.example.mygymapp.model.Line
-import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.model.Entry
+import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.Mood
+import com.example.mygymapp.model.Paragraph
 
 object JournalStore {
+    val currentEntry = mutableStateOf<Entry?>(null)
     val allLines = mutableStateListOf<Line>()
     val allParagraphs = mutableStateListOf<Paragraph>()
-    val currentEntry = mutableStateOf<Entry?>(null)
     val activeParagraph = mutableStateOf<Paragraph?>(null)
+    val currentMood = mutableStateOf<Mood?>(null)
 }

--- a/app/src/main/java/com/example/mygymapp/ui/components/EntryCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/EntryCard.kt
@@ -1,0 +1,33 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Entry
+import com.example.mygymapp.model.Mood
+
+/** Card showing a journal entry summary. */
+@Composable
+fun EntryCard(
+    entry: Entry,
+    mood: Mood? = null,
+    modifier: Modifier = Modifier
+) {
+    PoeticCard(modifier = modifier) {
+        Text(
+            text = "Entry on ${entry.date}",
+            fontFamily = FontFamily.Serif,
+            color = Color.Black
+        )
+        mood?.let {
+            Spacer(modifier = Modifier.height(8.dp))
+            MoodChip(mood = it)
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseItem.kt
@@ -1,0 +1,49 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mygymapp.data.Exercise
+
+/** A soft, poetic representation of a single exercise item. */
+@Composable
+fun ExerciseItem(
+    exercise: Exercise,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+            Text(
+                text = exercise.name,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontFamily = FontFamily.Serif,
+                    color = Color.Black
+                )
+            )
+            if (exercise.description.isNotBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = exercise.description,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = FontFamily.Serif,
+                        color = Color.DarkGray,
+                        fontSize = 12.sp
+                    ),
+                    maxLines = 2
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -1,12 +1,8 @@
 package com.example.mygymapp.ui.components
 
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -14,8 +10,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -36,96 +30,89 @@ fun LineCard(
     val fade by animateFloatAsState(if (line.isArchived) 0f else 1f, label = "fade")
     val gaeguRegular = FontFamily(Font(R.font.gaegu_regular))
     val gaeguBold = FontFamily(Font(R.font.gaegu_bold))
-    val gaeguLight = FontFamily(Font(R.font.gaegu_light))
     val textColor = Color(0xFF5D4037)
     val buttonBackground = Color(0xFFFFF8E1)
 
-    Card(
+    PoeticCard(
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)
-            .alpha(fade),
-        shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            .alpha(fade)
     ) {
-        Column(modifier = Modifier.padding(20.dp)) {
-            Text(
-                text = line.title,
-                style = TextStyle(
-                    fontFamily = gaeguBold,
-                    fontSize = 24.sp,
-                    color = textColor
-                )
+        Text(
+            text = line.title,
+            style = TextStyle(
+                fontFamily = gaeguBold,
+                fontSize = 24.sp,
+                color = textColor
             )
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
+            style = TextStyle(
+                fontFamily = gaeguRegular,
+                fontSize = 14.sp,
+                color = textColor
+            )
+        )
+        if (line.note.isNotBlank()) {
             Spacer(modifier = Modifier.height(6.dp))
             Text(
-                text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",
+                text = "📎 ${line.note}",
                 style = TextStyle(
                     fontFamily = gaeguRegular,
                     fontSize = 14.sp,
                     color = textColor
-                )
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
-            Column(modifier = Modifier.padding(20.dp)) {
-                Text(
-                    text = line.title,
-                    style = TextStyle(
-                        fontFamily = gaeguBold,
-                        fontSize = 24.sp,
-                        color = textColor
-                    )
+        }
+        if (line.exercises.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            line.exercises.forEach { ex ->
+                ExerciseItem(exercise = ex)
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            TextButton(
+                onClick = onEdit,
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = buttonBackground,
+                    contentColor = textColor
                 )
-                Spacer(modifier = Modifier.height(6.dp))
+            ) {
                 Text(
-                    text = "📎 ${line.note}",
-                    style = TextStyle(
-                        fontFamily = gaeguLight,
-                        fontSize = 14.sp,
-                        color = textColor
-                    ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    "✏️ Edit",
+                    style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(
-                    onClick = onEdit,
-                    colors = ButtonDefaults.textButtonColors(
-                        containerColor = buttonBackground,
-                        contentColor = textColor
-                    )
-                ) {
-                    Text(
-                        "✏️ Edit",
-                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
-                    )
-                }
-                TextButton(
-                    onClick = onAdd,
-                    colors = ButtonDefaults.textButtonColors(
-                        containerColor = buttonBackground,
-                        contentColor = textColor
-                    )
-                ) {
-                    Text(
-                        "📥 Add",
-                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
-                    )
-                }
-                TextButton(
-                    onClick = onArchive,
-                    colors = ButtonDefaults.textButtonColors(
-                        containerColor = buttonBackground,
-                        contentColor = textColor
-                    )
-                ) {
-                    Text(
-                        "📦 Archive",
-                        style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
-                    )
-                }
+            TextButton(
+                onClick = onAdd,
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = buttonBackground,
+                    contentColor = textColor
+                )
+            ) {
+                Text(
+                    "📥 Add",
+                    style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
+                )
+            }
+            TextButton(
+                onClick = onArchive,
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = buttonBackground,
+                    contentColor = textColor
+                )
+            ) {
+                Text(
+                    "📦 Archive",
+                    style = TextStyle(fontFamily = gaeguRegular, fontSize = 14.sp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/components/MoodChip.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/MoodChip.kt
@@ -1,0 +1,34 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.model.Mood
+
+/** Simple chip displaying the current mood. */
+@Composable
+fun MoodChip(
+    mood: Mood,
+    modifier: Modifier = Modifier
+) {
+    val label = mood.name.lowercase().replaceFirstChar { it.uppercase() }
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        color = Color(0xFFE0D8C8)
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            fontFamily = FontFamily.Serif,
+            color = Color.Black
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
@@ -1,15 +1,11 @@
 package com.example.mygymapp.ui.components
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.model.Paragraph
@@ -22,30 +18,23 @@ fun ParagraphCard(
     onSaveTemplate: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFF8E1)),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Column(modifier = Modifier.padding(20.dp)) {
+    PoeticCard(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = paragraph.title,
+            style = MaterialTheme.typography.headlineSmall.copy(fontFamily = FontFamily.Serif)
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        paragraph.lineTitles.forEachIndexed { index, title ->
             Text(
-                text = paragraph.title,
-                style = MaterialTheme.typography.headlineSmall.copy(fontFamily = FontFamily.Serif)
+                text = "Day ${index + 1}: $title",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
             )
-            Spacer(modifier = Modifier.height(12.dp))
-            paragraph.lineTitles.forEachIndexed { index, title ->
-                Text(
-                    text = "Day ${index + 1}: $title",
-                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Serif)
-                )
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(onClick = onEdit) { Text("✏️ Edit") }
-                TextButton(onClick = onPlan) { Text("📆 Plan") }
-                TextButton(onClick = onSaveTemplate) { Text("📎 Save Template") }
-            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            TextButton(onClick = onEdit) { Text("✏️ Edit") }
+            TextButton(onClick = onPlan) { Text("📆 Plan") }
+            TextButton(onClick = onSaveTemplate) { Text("📎 Save Template") }
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticCard.kt
@@ -1,0 +1,32 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * A soft card used throughout the app to mimic a book-like feel.
+ */
+@Composable
+fun PoeticCard(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = Color(0xFFFFF8E1),
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp), content = content)
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticOverlay.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticOverlay.kt
@@ -1,0 +1,44 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Fullscreen overlay used to confirm actions like saving.
+ */
+@Composable
+fun PoeticOverlay(
+    visible: Boolean,
+    message: String,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (!visible) return
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.8f))
+            .clickable { onDismiss() },
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            fontFamily = FontFamily.Serif,
+            fontSize = 20.sp,
+            color = Color.White,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryNavigation.kt
@@ -10,9 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.compose.runtime.collectAsState
+import com.example.mygymapp.store.JournalStore
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.example.mygymapp.viewmodel.EntryViewModel
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.Image
@@ -32,8 +29,7 @@ import com.example.mygymapp.R
 @Composable
 fun EntryNavigation(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
-    val vm: EntryViewModel = viewModel()
-    val entryNumber by vm.entryNumber.collectAsState()
+    val entryNumber = JournalStore.currentEntry.value?.id?.toInt() ?: 1
 
     NavHost(
         navController = navController,
@@ -41,13 +37,10 @@ fun EntryNavigation(modifier: Modifier = Modifier) {
         modifier = modifier
     ) {
         composable("entry") {
-            androidx.compose.runtime.LaunchedEffect(Unit) {
-                vm.refresh()
-            }
             EntryPage(
                 entryNumber = entryNumber,
                 onFinished = {
-                    vm.markFinished()
+                    JournalStore.currentEntry.value = null
                     navController.navigate("done")
                 }
             )

--- a/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/EntryPage.kt
@@ -31,6 +31,8 @@ import com.example.mygymapp.ui.theme.handwritingText
 import java.time.LocalDate
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Box
+import com.example.mygymapp.ui.components.MoodChip
+import com.example.mygymapp.store.JournalStore
 
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -62,6 +64,9 @@ import androidx.compose.foundation.layout.Box
                         entryNumber = entryNumber,
                         date = today
                     )
+                    JournalStore.currentMood.value?.let {
+                        MoodChip(mood = it)
+                    }
 
                         Text(
                             text = "Today: Push · 3 movements · 34 minutes",

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
@@ -1,8 +1,5 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -25,14 +22,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
+import com.example.mygymapp.store.JournalStore
 import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.components.PoeticLineCard
+import com.example.mygymapp.ui.components.PoeticOverlay
 import com.example.mygymapp.ui.pages.GaeguBold
 import com.example.mygymapp.ui.pages.GaeguRegular
-import com.example.mygymapp.viewmodel.LineViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.compose.ui.text.font.FontFamily
@@ -51,8 +48,7 @@ fun ParagraphEditorPageSwipe(
     var title by remember(initial) { mutableStateOf(initial?.title ?: "") }
     var note by remember(initial) { mutableStateOf(initial?.note ?: "") }
 
-    val lineViewModel: LineViewModel = viewModel()
-    val lines by lineViewModel.lines.collectAsState()
+    val lines = JournalStore.allLines
     val selectedLines = remember { mutableStateListOf<Line?>().apply { repeat(7) { add(null) } } }
 
     LaunchedEffect(initial, lines) {
@@ -400,24 +396,11 @@ fun ParagraphEditorPageSwipe(
                     Text("📜 Save this paragraph", fontFamily = GaeguRegular, color = Color.Black)
                 }
 
-                AnimatedVisibility(
+                PoeticOverlay(
                     visible = showSavedOverlay,
-                    enter = fadeIn(),
-                    exit = fadeOut()
-                ) {
-                    Box(
-                        Modifier
-                            .fillMaxSize()
-                            .background(Color.Black.copy(alpha = 0.8f)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            "A new chapter has been written...",
-                            color = Color.White,
-                            style = TextStyle(fontFamily = GaeguBold, fontSize = 20.sp)
-                        )
-                    }
-                }
+                    message = "A new chapter has been written...",
+                    onDismiss = { showSavedOverlay = false }
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorScreen.kt
@@ -1,28 +1,25 @@
 package com.example.mygymapp.ui.pages
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.navigation.NavController
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.mygymapp.viewmodel.ParagraphViewModel
+import com.example.mygymapp.store.JournalStore
 
 @Composable
 fun ParagraphEditorScreen(
     navController: NavController,
     editId: Long? = null,
-    paragraphViewModel: ParagraphViewModel = viewModel()
 ) {
-    val paragraphs by paragraphViewModel.paragraphs.collectAsState()
+    val paragraphs = JournalStore.allParagraphs
     val initial = paragraphs.find { it.id == editId }
 
     ParagraphEditorPageSwipe(
         initial = initial,
         onSave = { paragraph ->
             if (initial != null) {
-                paragraphViewModel.editParagraph(paragraph)
+                val index = paragraphs.indexOfFirst { it.id == paragraph.id }
+                if (index >= 0) paragraphs[index] = paragraph
             } else {
-                paragraphViewModel.addParagraph(paragraph)
+                paragraphs.add(paragraph)
             }
             navController.navigate("line_paragraph?tab=1") {
                 popUpTo("line_paragraph?tab=0") { inclusive = true }


### PR DESCRIPTION
## Summary
- centralize journal data in new `JournalStore` with mood tracking
- add soft `PoeticCard`, `MoodChip`, `ExerciseItem`, and `PoeticOverlay` components
- update line, paragraph, and entry screens to use `JournalStore` and new components

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f590096d4832a9601c4c8f545f501