### PR TITLE
Fix crash when adding line by using in-place editor

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -56,7 +56,10 @@ fun LineParagraphPage(
                             showLineEditor = true
                         },
                         onArchive = { lines.remove(it) },
-                        onAdd = { navController.navigate("line_editor") },
+                        onAdd = {
+                            editingLine = null
+                            showLineEditor = true
+                        },
                         onManageExercises = { navController.navigate("exercise_management") }
                     )
                     else -> ParagraphsPage(


### PR DESCRIPTION
## Summary
- Avoid navigating to missing `line_editor` destination by showing the editor inline

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f5f933998832a8eb00703b99a4730