### PR TITLE
Refine line editor with mood and structured fields

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Line.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Line.kt
@@ -1,6 +1,7 @@
 package com.example.mygymapp.model
 
 import com.example.mygymapp.model.Exercise
+import com.example.mygymapp.model.Mood
 
 /**
  * Represents a single daily workout "Line" in the training diary.
@@ -10,6 +11,7 @@ data class Line(
     val title: String,
     val category: String,
     val muscleGroup: String,
+    val mood: Mood? = null,
     val exercises: List<Exercise>,
     val supersets: List<Pair<Long, Long>>, // pair of exercise ids forming a superset
     val note: String,

--- a/app/src/main/java/com/example/mygymapp/model/Mood.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Mood.kt
@@ -1,11 +1,10 @@
 package com.example.mygymapp.model
 
-/** Simple mood indicator for an entry. */
+/** Soft mood states used to color journal lines. */
 enum class Mood {
-    HAPPY,
-    NEUTRAL,
-    SAD,
-    ENERGETIC,
-    TIRED
+    CALM,
+    FOCUSED,
+    BALANCED,
+    SEARCHING
 }
 

--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.Alignment
 import com.example.mygymapp.R
 import com.example.mygymapp.model.Line
 
@@ -37,14 +38,20 @@ fun LineCard(
         modifier = modifier
             .alpha(fade)
     ) {
-        Text(
-            text = line.title,
-            style = TextStyle(
-                fontFamily = gaeguBold,
-                fontSize = 24.sp,
-                color = textColor
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = line.title,
+                style = TextStyle(
+                    fontFamily = gaeguBold,
+                    fontSize = 24.sp,
+                    color = textColor
+                )
             )
-        )
+            line.mood?.let {
+                Spacer(modifier = Modifier.width(8.dp))
+                MoodChip(mood = it)
+            }
+        }
         Spacer(modifier = Modifier.height(6.dp))
         Text(
             text = "${line.exercises.size} exercises · ${line.supersets.size} superset${if (line.supersets.size == 1) "" else "s"}",

--- a/app/src/main/java/com/example/mygymapp/ui/components/MoodChip.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/MoodChip.kt
@@ -1,5 +1,7 @@
 package com.example.mygymapp.ui.components
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
@@ -15,13 +17,22 @@ import com.example.mygymapp.model.Mood
 @Composable
 fun MoodChip(
     mood: Mood,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    selected: Boolean = false,
+    onClick: (() -> Unit)? = null
 ) {
     val label = mood.name.lowercase().replaceFirstChar { it.uppercase() }
+    val color = when (mood) {
+        Mood.CALM -> Color(0xFFD0E8F2)
+        Mood.FOCUSED -> Color(0xFFE8E0F7)
+        Mood.BALANCED -> Color(0xFFE0F2E9)
+        Mood.SEARCHING -> Color(0xFFF7E0E0)
+    }
     Surface(
-        modifier = modifier,
+        modifier = modifier.then(if (onClick != null) Modifier.clickable { onClick() } else Modifier),
         shape = RoundedCornerShape(16.dp),
-        color = Color(0xFFE0D8C8)
+        color = color,
+        border = if (selected) BorderStroke(2.dp, Color.Black) else null
     ) {
         Text(
             text = label,

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -1,25 +1,57 @@
 package com.example.mygymapp.ui.pages
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.Mood
+import com.example.mygymapp.ui.components.ExerciseItem
+import com.example.mygymapp.ui.components.MoodChip
 import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.components.PoeticCard
+import com.example.mygymapp.viewmodel.ExerciseViewModel
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun LineEditorPage(
     initial: Line? = null,
     onSave: (Line) -> Unit,
     onCancel: () -> Unit
 ) {
+    val vm: ExerciseViewModel = viewModel()
+    val allExercises by vm.allExercises.observeAsState(emptyList())
+
     var title by remember { mutableStateOf(initial?.title ?: "") }
     var category by remember { mutableStateOf(initial?.category ?: "") }
     var muscleGroup by remember { mutableStateOf(initial?.muscleGroup ?: "") }
     var note by remember { mutableStateOf(initial?.note ?: "") }
+    var mood by remember { mutableStateOf(initial?.mood ?: Mood.CALM) }
+
+    val selectedExercises = remember {
+        mutableStateListOf<com.example.mygymapp.model.Exercise>().apply {
+            initial?.exercises?.let { addAll(it) }
+        }
+    }
+    val supersets = remember { mutableStateListOf<Pair<Long, Long>>().apply { initial?.supersets?.let { addAll(it) } } }
+
+    var search by remember { mutableStateOf("") }
+
+    val categoryOptions = listOf("Push", "Pull", "Core", "Cardio", "Recovery")
+    val muscleOptions = listOf("Back", "Legs", "Core", "Shoulders", "Chest", "Full Body")
 
     PaperBackground(
         modifier = Modifier
@@ -39,15 +71,70 @@ fun LineEditorPage(
                 fontSize = 20.sp,
                 modifier = Modifier.align(Alignment.CenterHorizontally)
             )
-            TextField(value = title, onValueChange = { title = it }, label = { Text("Title") })
-            TextField(value = category, onValueChange = { category = it }, label = { Text("Category") })
-            TextField(value = muscleGroup, onValueChange = { muscleGroup = it }, label = { Text("Muscle Group") })
-            TextField(
-                value = note,
-                onValueChange = { note = it },
-                label = { Text("Note") },
-                modifier = Modifier.heightIn(min = 120.dp)
+            PoeticCard {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    OutlinedTextField(
+                        value = title,
+                        onValueChange = { title = it },
+                        label = { Text("Title") },
+                        textStyle = TextStyle(fontFamily = GaeguRegular)
+                    )
+                    DropdownField("Category", category, { category = it }, categoryOptions)
+                    DropdownField("Muscle Group", muscleGroup, { muscleGroup = it }, muscleOptions)
+                    Text("Mood", fontFamily = GaeguBold)
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Mood.values().forEach { m ->
+                            MoodChip(mood = m, selected = m == mood, onClick = { mood = m })
+                        }
+                    }
+                    OutlinedTextField(
+                        value = note,
+                        onValueChange = { note = it },
+                        label = { Text("Note") },
+                        modifier = Modifier.heightIn(min = 80.dp),
+                        textStyle = TextStyle(fontFamily = GaeguRegular)
+                    )
+                }
+            }
+
+            OutlinedTextField(
+                value = search,
+                onValueChange = { search = it },
+                label = { Text("Filter saved exercises") },
+                modifier = Modifier.fillMaxWidth(),
+                textStyle = TextStyle(fontFamily = GaeguRegular)
             )
+
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                items(allExercises.filter { it.name.contains(search, ignoreCase = true) }) { ex ->
+                    ExerciseRow(ex) {
+                        selectedExercises.add(
+                            com.example.mygymapp.model.Exercise(
+                                id = ex.id,
+                                name = ex.name,
+                                sets = 3,
+                                repsOrDuration = "10"
+                            )
+                        )
+                    }
+                }
+            }
+
+            if (selectedExercises.isNotEmpty()) {
+                Text("Today's plan", fontFamily = GaeguBold)
+                PoeticCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        val supersetMap = supersets.mapIndexed { index, pair -> pair.first to index }.toMap()
+                        selectedExercises.forEach { ex ->
+                            val label = supersetMap[ex.id]?.let { idx -> "Superset ${(65 + idx).toChar()}" }
+                            label?.let { Text(it, fontFamily = GaeguBold) }
+                            ExerciseItem(exercise = ex)
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                    }
+                }
+            }
+
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 TextButton(onClick = onCancel) { Text("Cancel", fontFamily = GaeguRegular) }
                 Spacer(Modifier.width(16.dp))
@@ -57,8 +144,9 @@ fun LineEditorPage(
                         title = title,
                         category = category,
                         muscleGroup = muscleGroup,
-                        exercises = initial?.exercises ?: emptyList(),
-                        supersets = initial?.supersets ?: emptyList(),
+                        mood = mood,
+                        exercises = selectedExercises.toList(),
+                        supersets = supersets.toList(),
                         note = note,
                         isArchived = false
                     )
@@ -68,5 +156,41 @@ fun LineEditorPage(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DropdownField(label: String, value: String, onValueChange: (String) -> Unit, options: List<String>) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor().fillMaxWidth(),
+            textStyle = TextStyle(fontFamily = GaeguRegular)
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(text = { Text(option) }, onClick = { onValueChange(option); expanded = false })
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExerciseRow(ex: Exercise, onAdd: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onAdd() }
+            .padding(vertical = 8.dp)
+    ) {
+        Text(ex.name, fontFamily = GaeguRegular)
+        Spacer(modifier = Modifier.weight(1f))
+        Text("3 × 10", fontFamily = GaeguRegular)
     }
 }

--- a/app/src/main/java/com/example/mygymapp/viewmodel/LineViewModel.kt
+++ b/app/src/main/java/com/example/mygymapp/viewmodel/LineViewModel.kt
@@ -3,6 +3,7 @@ package com.example.mygymapp.viewmodel
 import androidx.lifecycle.ViewModel
 import com.example.mygymapp.data.LineRepository
 import com.example.mygymapp.model.Line
+import com.example.mygymapp.model.Mood
 import kotlinx.coroutines.flow.StateFlow
 
 class LineViewModel : ViewModel() {
@@ -16,6 +17,7 @@ class LineViewModel : ViewModel() {
                 title = "Silent Force",
                 category = "Push",
                 muscleGroup = "Core",
+                mood = Mood.CALM,
                 exercises = emptyList(),
                 supersets = emptyList(),
                 note = "Felt steady and grounded throughout."
@@ -27,6 +29,7 @@ class LineViewModel : ViewModel() {
                 title = "Night Owl Session",
                 category = "Pull",
                 muscleGroup = "Back",
+                mood = Mood.FOCUSED,
                 exercises = emptyList(),
                 supersets = listOf(1L to 2L),
                 note = "Late session with high focus."


### PR DESCRIPTION
## Summary
- Add Calm/Focussed/Balanced/Searching mood system with colored `MoodChip`
- Expand `Line` model and card to show optional mood
- Redesign LineEditorPage with dropdowns, mood selection and exercise picker

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f72378600832a81663a4fb4dc3a14