### PR TITLE
Fix line alignment in LinedTextField

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -15,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.ui.pages.GaeguLight
 import com.example.mygymapp.ui.pages.GaeguRegular
+import android.graphics.Paint
 
 @Composable
 fun LinedTextField(
@@ -26,9 +28,23 @@ fun LinedTextField(
     minLines: Int = 4
 ) {
     val density = LocalDensity.current
-    val lineHeightPx = with(density) { lineHeight.toPx() }
+    val textStyle = TextStyle(
+        fontSize = 18.sp,
+        lineHeight = lineHeight.value.sp,
+        fontFamily = GaeguRegular,
+        color = Color.Black
+    )
+
+    val lineHeightPx = with(density) { textStyle.lineHeight.toPx() }
     val lineCount = maxOf(value.lineSequence().count() + 1, minLines)
-    val height = lineHeight * lineCount
+    val height = with(density) { lineHeightPx.toDp() } * lineCount
+
+    val paint = remember(density) {
+        Paint().apply { textSize = with(density) { textStyle.fontSize.toPx() } }
+    }
+    val fm = paint.fontMetrics
+    val textHeight = fm.descent - fm.ascent
+    val baselineOffset = (lineHeightPx - textHeight) / 2f - fm.ascent
 
     Box(
         modifier = modifier
@@ -38,7 +54,7 @@ fun LinedTextField(
     ) {
         Canvas(modifier = Modifier.matchParentSize()) {
             for (i in 0 until lineCount) {
-                val y = i * lineHeightPx + lineHeightPx * 0.92f
+                val y = baselineOffset + i * lineHeightPx
                 drawLine(
                     color = Color.Black,
                     start = Offset(0f, y),
@@ -51,12 +67,7 @@ fun LinedTextField(
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
-            textStyle = TextStyle(
-                fontSize = 18.sp,
-                lineHeight = lineHeight.value.sp,
-                fontFamily = GaeguRegular,
-                color = Color.Black
-            ),
+            textStyle = textStyle,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 8.dp)


### PR DESCRIPTION
## Summary
- compute baseline offset from font metrics and line height
- use consistent sp-based line spacing to keep text on drawn lines across multiple lines

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa14eab98832a9a9f4c97332896ca