### PR TITLE
Fix line alignment in LinedTextField

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
@@ -1,15 +1,22 @@
 package com.example.mygymapp.ui.components
 
+import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.getLineBottom
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -26,9 +33,39 @@ fun LinedTextField(
     minLines: Int = 4
 ) {
     val density = LocalDensity.current
-    val lineHeightPx = with(density) { lineHeight.toPx() }
-    val lineCount = maxOf(value.lineSequence().count() + 1, minLines)
-    val height = lineHeight * lineCount
+    val textStyle = TextStyle(
+        fontSize = 18.sp,
+        lineHeight = lineHeight.value.sp,
+        fontFamily = GaeguRegular,
+        color = Color.Black
+    )
+    val lineHeightPx = with(density) { textStyle.lineHeight.toPx() }
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    val layout = layoutResult
+
+    // Compute descent from the font metrics so we can translate the layout's
+    // line bottoms to baselines and generate additional baselines for empty
+    // trailing lines.
+    val fontSizePx = with(density) { textStyle.fontSize.toPx() }
+    val paint = remember { Paint() }
+    paint.textSize = fontSizePx
+    val fontMetrics = paint.fontMetrics
+    val descent = fontMetrics.descent
+    val baselineOffset = -fontMetrics.ascent
+
+    // Use the layout's measured line spacing when available so that
+    // additional lines are spaced identically to the rendered text.
+    val baselineSpacing = layout?.let {
+        if (it.lineCount > 1) {
+            (it.getLineBottom(1) - it.getLineBottom(0)).toFloat()
+        } else {
+            lineHeightPx
+        }
+    } ?: lineHeightPx
+
+    val textLineCount = layout?.lineCount ?: 0
+    val lineCount = maxOf(textLineCount, minLines)
+    val height = with(density) { (baselineSpacing * lineCount).toDp() }
 
     Box(
         modifier = modifier
@@ -37,12 +74,27 @@ fun LinedTextField(
             .padding(4.dp)
     ) {
         Canvas(modifier = Modifier.matchParentSize()) {
+            val lastBaseline = if (layout != null && layout.lineCount > 0) {
+                layout.getLineBottom(layout.lineCount - 1) - descent
+            } else {
+                baselineOffset
+            }
+
             for (i in 0 until lineCount) {
-                val y = i * lineHeightPx + lineHeightPx * 0.92f
+                val baseline = if (layout != null) {
+                    if (i < layout.lineCount) {
+                        layout.getLineBottom(i) - descent
+                    } else {
+                        lastBaseline + (i - layout.lineCount + 1) * baselineSpacing
+                    }
+                } else {
+                    baselineOffset + i * baselineSpacing
+                }
+
                 drawLine(
                     color = Color.Black,
-                    start = Offset(0f, y),
-                    end = Offset(size.width, y),
+                    start = Offset(0f, baseline),
+                    end = Offset(size.width, baseline),
                     strokeWidth = 1.2f
                 )
             }
@@ -51,15 +103,11 @@ fun LinedTextField(
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
-            textStyle = TextStyle(
-                fontSize = 18.sp,
-                lineHeight = lineHeight.value.sp,
-                fontFamily = GaeguRegular,
-                color = Color.Black
-            ),
+            textStyle = textStyle,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 8.dp)
+                .padding(horizontal = 8.dp),
+            onTextLayout = { layoutResult = it }
         ) { innerTextField ->
             if (value.isEmpty()) {
                 Text(


### PR DESCRIPTION
## Summary
- derive baseline spacing from layout line bottoms and font metrics to align text with drawn lines
- draw guidelines using baselines computed from line bottoms to avoid unsupported getLineBaseline call

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa14eab98832a9a9f4c97332896ca