### PR TITLE
Fix line alignment in LinedTextField

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
@@ -1,14 +1,16 @@
 package com.example.mygymapp.ui.components
 
+import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -26,9 +28,28 @@ fun LinedTextField(
     minLines: Int = 4
 ) {
     val density = LocalDensity.current
-    val lineHeightPx = with(density) { lineHeight.toPx() }
-    val lineCount = maxOf(value.lineSequence().count() + 1, minLines)
-    val height = lineHeight * lineCount
+    val textStyle = TextStyle(
+        fontSize = 18.sp,
+        lineHeight = lineHeight.value.sp,
+        fontFamily = GaeguRegular,
+        color = Color.Black
+    )
+
+    val lineHeightPx = with(density) { textStyle.lineHeight.toPx() }
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    val metrics = remember(textStyle.fontSize, density) {
+        Paint().apply {
+            textSize = with(density) { textStyle.fontSize.toPx() }
+        }.fontMetrics
+    }
+    val descent = metrics.descent
+    val baselineOffset = -metrics.ascent
+
+    val lineCount = maxOf(layoutResult?.lineCount ?: 0, minLines)
+    val height = with(density) {
+        (baselineOffset + descent + (lineCount - 1) * lineHeightPx).toDp()
+    }
 
     Box(
         modifier = modifier
@@ -38,11 +59,11 @@ fun LinedTextField(
     ) {
         Canvas(modifier = Modifier.matchParentSize()) {
             for (i in 0 until lineCount) {
-                val y = i * lineHeightPx + lineHeightPx * 0.92f
+                val baseline = baselineOffset + i * lineHeightPx
                 drawLine(
                     color = Color.Black,
-                    start = Offset(0f, y),
-                    end = Offset(size.width, y),
+                    start = Offset(0f, baseline),
+                    end = Offset(size.width, baseline),
                     strokeWidth = 1.2f
                 )
             }
@@ -51,15 +72,11 @@ fun LinedTextField(
         BasicTextField(
             value = value,
             onValueChange = onValueChange,
-            textStyle = TextStyle(
-                fontSize = 18.sp,
-                lineHeight = lineHeight.value.sp,
-                fontFamily = GaeguRegular,
-                color = Color.Black
-            ),
+            textStyle = textStyle,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 8.dp)
+                .padding(horizontal = 8.dp),
+            onTextLayout = { layoutResult = it }
         ) { innerTextField ->
             if (value.isEmpty()) {
                 Text(
@@ -74,3 +91,4 @@ fun LinedTextField(
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- derive baseline offset from font metrics using a single remembered `Paint`
- start guideline drawing from the first line's baseline to keep text and lines synchronized

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa14eab98832a9a9f4c97332896ca