### PR TITLE
Fix and simplify LinedTextField component

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
@@ -2,7 +2,6 @@ package com.example.mygymapp.ui.components
 
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
@@ -13,11 +12,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.getLineBottom
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlin.math.roundToInt
 import com.example.mygymapp.ui.pages.GaeguLight
 import com.example.mygymapp.ui.pages.GaeguRegular
 
@@ -46,84 +43,14 @@ fun LinedTextField(
             textSize = with(density) { textStyle.fontSize.toPx() }
         }.fontMetrics
     }
-    val descent = metrics.descent
     val baselineOffset = -metrics.ascent
 
     val lineCount = maxOf(layoutResult?.lineCount ?: 0, minLines)
-    val height = with(density) {
-        (baselineOffset + descent + (lineCount - 1) * lineHeightPx).toDp()
-    }
-
-    // Compute descent from the font metrics so we can translate the layout's
-    // line bottoms to baselines and generate additional baselines for empty
-    // trailing lines.
-    val metrics = remember(textStyle.fontSize, density) {
-        Paint().apply {
-            textSize = with(density) { textStyle.fontSize.toPx() }
-        }.fontMetrics
-    }
-    val descent = metrics.descent
-    val baselineOffset = -metrics.ascent
-
-    val layout = layoutResult
-    // Use the layout's measured line spacing when available so that
-    // additional lines are spaced identically to the rendered text.
-    val baselineSpacing = layout?.let {
-        if (it.lineCount > 1) {
-            (it.getLineBottom(1) - it.getLineBottom(0)).toFloat()
-        } else {
-            lineHeightPx
-        }
-    } ?: lineHeightPx
-
-    val lineCount = maxOf(layout?.lineCount ?: 0, minLines)
-    val height = with(density) { (baselineSpacing * lineCount).toDp() }
-
-    // Compute descent from the font metrics so we can translate the layout's
-    // line bottoms to baselines and generate additional baselines for empty
-    // trailing lines.
-    val fontSizePx = with(density) { textStyle.fontSize.toPx() }
-    val paint = remember { Paint() }
-    paint.textSize = fontSizePx
-    val fontMetrics = paint.fontMetrics
-    val descent = fontMetrics.descent
-    val baselineOffset = -fontMetrics.ascent
-
-    val layout = layoutResult
-    // Use the layout's measured line spacing when available so that
-    // additional lines are spaced identically to the rendered text.
-    val baselineSpacing = layout?.let {
-        if (it.lineCount > 1) {
-            (it.getLineBottom(1) - it.getLineBottom(0)).toFloat()
-        } else {
-            lineHeightPx
-        }
-    } ?: lineHeightPx
-
-    val lineCount = maxOf(layout?.lineCount ?: 0, minLines)
-    val height = with(density) { (baselineSpacing * lineCount).toDp() }
-
-    // Compute descent from the font metrics so we can translate the layout's
-    // line bottoms to baselines and generate additional baselines for empty
-    // trailing lines.
-    val fontSizePx = with(density) { textStyle.fontSize.toPx() }
-    val paint = remember { Paint() }
-    paint.textSize = fontSizePx
-    val fontMetrics = paint.fontMetrics
-    val descent = fontMetrics.descent
-    val baselineOffset = -fontMetrics.ascent
 
     BoxWithConstraints(
         modifier = modifier.fillMaxWidth()
     ) {
         Canvas(modifier = Modifier.matchParentSize()) {
-            val lastBaseline = if (layout != null && layout.lineCount > 0) {
-                layout.getLineBottom(layout.lineCount - 1) - descent
-            } else {
-                // Start extra baselines from the first line's baseline when no text is present
-                baselineOffset - baselineSpacing
-            }
-
             for (i in 0 until lineCount) {
                 val baseline = baselineOffset + i * lineHeightPx
                 drawLine(


### PR DESCRIPTION
## Summary
- remove redundant baseline calculations and duplicate variables
- draw guide lines directly using a single baseline offset

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbc3a1cc8832a820351584ba35747