### PR TITLE
Expose initial line count and align hint for LinedTextField

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
@@ -2,7 +2,6 @@ package com.example.mygymapp.ui.components
 
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
@@ -13,11 +12,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.getLineBottom
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlin.math.roundToInt
 import com.example.mygymapp.ui.pages.GaeguLight
 import com.example.mygymapp.ui.pages.GaeguRegular
 
@@ -28,7 +25,7 @@ fun LinedTextField(
     hint: String,
     modifier: Modifier = Modifier,
     lineHeight: Dp = 32.dp,
-    minLines: Int = 4
+    initialLines: Int = 1
 ) {
     val density = LocalDensity.current
     val textStyle = TextStyle(
@@ -46,90 +43,25 @@ fun LinedTextField(
             textSize = with(density) { textStyle.fontSize.toPx() }
         }.fontMetrics
     }
-    val descent = metrics.descent
     val baselineOffset = -metrics.ascent
 
-    val lineCount = maxOf(layoutResult?.lineCount ?: 0, minLines)
-    val height = with(density) {
-        (baselineOffset + descent + (lineCount - 1) * lineHeightPx).toDp()
-    }
+    val lineCount = maxOf(layoutResult?.lineCount ?: 1, initialLines)
 
-    // Compute descent from the font metrics so we can translate the layout's
-    // line bottoms to baselines and generate additional baselines for empty
-    // trailing lines.
-    val metrics = remember(textStyle.fontSize, density) {
-        Paint().apply {
-            textSize = with(density) { textStyle.fontSize.toPx() }
-        }.fontMetrics
-    }
-    val descent = metrics.descent
-    val baselineOffset = -metrics.ascent
-
-    val layout = layoutResult
-    // Use the layout's measured line spacing when available so that
-    // additional lines are spaced identically to the rendered text.
-    val baselineSpacing = layout?.let {
-        if (it.lineCount > 1) {
-            (it.getLineBottom(1) - it.getLineBottom(0)).toFloat()
-        } else {
-            lineHeightPx
-        }
-    } ?: lineHeightPx
-
-    val lineCount = maxOf(layout?.lineCount ?: 0, minLines)
-    val height = with(density) { (baselineSpacing * lineCount).toDp() }
-
-    // Compute descent from the font metrics so we can translate the layout's
-    // line bottoms to baselines and generate additional baselines for empty
-    // trailing lines.
-    val fontSizePx = with(density) { textStyle.fontSize.toPx() }
-    val paint = remember { Paint() }
-    paint.textSize = fontSizePx
-    val fontMetrics = paint.fontMetrics
-    val descent = fontMetrics.descent
-    val baselineOffset = -fontMetrics.ascent
-
-    val layout = layoutResult
-    // Use the layout's measured line spacing when available so that
-    // additional lines are spaced identically to the rendered text.
-    val baselineSpacing = layout?.let {
-        if (it.lineCount > 1) {
-            (it.getLineBottom(1) - it.getLineBottom(0)).toFloat()
-        } else {
-            lineHeightPx
-        }
-    } ?: lineHeightPx
-
-    val lineCount = maxOf(layout?.lineCount ?: 0, minLines)
-    val height = with(density) { (baselineSpacing * lineCount).toDp() }
-
-    // Compute descent from the font metrics so we can translate the layout's
-    // line bottoms to baselines and generate additional baselines for empty
-    // trailing lines.
-    val fontSizePx = with(density) { textStyle.fontSize.toPx() }
-    val paint = remember { Paint() }
-    paint.textSize = fontSizePx
-    val fontMetrics = paint.fontMetrics
-    val descent = fontMetrics.descent
-    val baselineOffset = -fontMetrics.ascent
-
-    BoxWithConstraints(
+    Box(
         modifier = modifier.fillMaxWidth()
     ) {
         Canvas(modifier = Modifier.matchParentSize()) {
-            val lastBaseline = if (layout != null && layout.lineCount > 0) {
-                layout.getLineBottom(layout.lineCount - 1) - descent
-            } else {
-                // Start extra baselines from the first line's baseline when no text is present
-                baselineOffset - baselineSpacing
-            }
-
+            val layout = layoutResult
             for (i in 0 until lineCount) {
-                val baseline = baselineOffset + i * lineHeightPx
+                val y = if (layout != null && i < layout.lineCount) {
+                    layout.getLineBaseline(i)
+                } else {
+                    baselineOffset + i * lineHeightPx
+                }
                 drawLine(
                     color = Color.Black,
-                    start = Offset(0f, baseline),
-                    end = Offset(size.width, baseline),
+                    start = Offset(0f, y),
+                    end = Offset(size.width, y),
                     strokeWidth = 1.2f
                 )
             }
@@ -152,8 +84,8 @@ fun LinedTextField(
                     lineHeight = lineHeight.value.sp,
                     color = Color.Gray
                 )
-
             }
+            innerTextField()
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -77,7 +77,8 @@ fun LineEditorPage(
             LinedTextField(
                 value = title,
                 onValueChange = { title = it },
-                hint = "A poetic title..."
+                hint = "A poetic title...",
+                initialLines = 1
             )
 
 
@@ -124,7 +125,7 @@ fun LineEditorPage(
                 value = note,
                 onValueChange = { note = it },
                 hint = "Write your thoughts here...",
-                minLines = 4
+                initialLines = 3
             )
 
 


### PR DESCRIPTION
## Summary
- allow LinedTextField callers to define starting guide lines
- draw guide lines on text baselines so placeholder text rests on the line
- update LineEditorPage to pass custom initial line counts

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbc3a1cc8832a820351584ba35747