### PR TITLE
Add poetic chip selectors and wax seal button

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticMultiSelectChips.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticMultiSelectChips.kt
@@ -1,0 +1,65 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.ui.pages.GaeguRegular
+
+/**
+ * A poetic chip selector allowing multiple selections.
+ * Styled gently with rounded corners and soft selection highlights.
+ */
+@Composable
+fun PoeticMultiSelectChips(
+    options: List<String>,
+    selectedItems: List<String>,
+    onSelectionChange: (List<String>) -> Unit,
+    modifier: Modifier = Modifier,
+    font: FontFamily = GaeguRegular,
+    selectedBackground: Color = Color(0xFFD7CCC8),
+    unselectedBackground: Color = Color.Transparent,
+    textColor: Color = Color.Black,
+    spacing: Dp = 8.dp
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing),
+        verticalArrangement = Arrangement.spacedBy(spacing)
+    ) {
+        options.forEach { option ->
+            val isSelected = option in selectedItems
+            Surface(
+                color = if (isSelected) selectedBackground else unselectedBackground,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .clickable {
+                        val updated = if (isSelected) {
+                            selectedItems - option
+                        } else {
+                            selectedItems + option
+                        }
+                        onSelectionChange(updated)
+                    }
+                    .padding(horizontal = 4.dp)
+            ) {
+                Text(
+                    text = option,
+                    fontFamily = font,
+                    color = textColor,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticRadioChips.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticRadioChips.kt
@@ -1,0 +1,58 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.ui.pages.GaeguRegular
+
+/**
+ * A poetic set of radio-style choice chips for selecting exactly one option.
+ * Styled softly with rounded corners and font-family support for a book-like feel.
+ */
+@Composable
+fun PoeticRadioChips(
+    options: List<String>,
+    selected: String?,
+    onSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    font: FontFamily = GaeguRegular,
+    selectedBackground: Color = Color(0xFFD7CCC8),
+    unselectedBackground: Color = Color.Transparent,
+    textColor: Color = Color.Black,
+    spacing: Dp = 8.dp
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing),
+        verticalArrangement = Arrangement.spacedBy(spacing)
+    ) {
+        options.forEach { option ->
+            val isSelected = option == selected
+            Surface(
+                color = if (isSelected) selectedBackground else unselectedBackground,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .clickable { onSelected(option) }
+                    .padding(horizontal = 4.dp)
+            ) {
+                Text(
+                    text = option,
+                    fontFamily = font,
+                    color = textColor,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/WaxSealButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/WaxSealButton.kt
@@ -1,0 +1,69 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.material3.Text
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Offset
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mygymapp.R
+import com.example.mygymapp.ui.pages.GaeguBold
+
+/**
+ * A poetic action button using a wax seal illustration.
+ * Displays centered label text over a wax image (e.g. for Save/Create/Finish actions).
+ * Designed for consistent use across all major actions in the app.
+ */
+@Composable
+fun WaxSealButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    imageRes: Int = R.drawable.waxseal,
+    font: FontFamily = GaeguBold,
+    textColor: Color = Color.White,
+    textSize: TextUnit = 16.sp,
+    shadowColor: Color = Color.Black,
+    shadowOffset: Offset = Offset(1f, 1f),
+    sealSize: Dp = 100.dp
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(sealSize)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(imageRes),
+            contentDescription = label,
+            modifier = Modifier.size(sealSize),
+            contentScale = ContentScale.Fit
+        )
+        Text(
+            text = label,
+            style = TextStyle(
+                fontFamily = font,
+                fontSize = textSize,
+                shadow = Shadow(shadowColor, shadowOffset, blurRadius = 2f),
+                color = textColor
+            )
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PoeticRadioChips for single-selection chips using Gaegu styling
- add PoeticMultiSelectChips for multi-selection chips with soft highlights
- add WaxSealButton for wax-seal themed actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fcddabffc832a818989da0bd95416