### PR TITLE
Add superset management to line editor

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -32,8 +32,10 @@ fun ReorderableExerciseItem(
     index: Int,
     exercise: LineExercise,
     onRemove: () -> Unit,
+    onSupersetClick: () -> Unit,
     modifier: Modifier = Modifier,
-    dragHandle: @Composable () -> Unit
+    dragHandle: @Composable () -> Unit,
+    supersetWithIndex: Int? = null
 ) {
     Surface(
         shape = RoundedCornerShape(12.dp),
@@ -41,49 +43,62 @@ fun ReorderableExerciseItem(
         tonalElevation = 2.dp,
         modifier = modifier
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            // Index & Name
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = "${index + 1}.",
-                    fontFamily = GaeguBold,
-                    fontSize = 16.sp,
-                    modifier = Modifier.padding(end = 8.dp)
-                )
-                Column {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                // Index & Name
+                Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = exercise.name,
-                        fontFamily = GaeguRegular,
-                        fontSize = 16.sp
+                        text = "${index + 1}.",
+                        fontFamily = GaeguBold,
+                        fontSize = 16.sp,
+                        modifier = Modifier.padding(end = 8.dp)
                     )
-                    exercise.repsOrDuration?.let {
+                    Column {
                         Text(
-                            text = "e.g. $it reps",
-                            fontFamily = GaeguLight,
-                            fontSize = 12.sp,
-                            color = Color.Gray
+                            text = exercise.name,
+                            fontFamily = GaeguRegular,
+                            fontSize = 16.sp
+                        )
+                        exercise.repsOrDuration?.let {
+                            Text(
+                                text = "e.g. $it reps",
+                                fontFamily = GaeguLight,
+                                fontSize = 12.sp,
+                                color = Color.Gray
+                            )
+                        }
+                    }
+                }
+
+                // Actions
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = onRemove) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete",
+                            tint = Color.Red
                         )
                     }
+                    IconButton(onClick = onSupersetClick) {
+                        Text("🧷", fontSize = 18.sp)
+                    }
+                    dragHandle()
                 }
             }
 
-            // Actions
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = onRemove) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = "Delete",
-                        tint = Color.Red
-                    )
-                }
-
-                dragHandle()
+            if (supersetWithIndex != null) {
+                Text(
+                    text = "🧷 Superset with #${supersetWithIndex + 1}",
+                    fontFamily = GaeguLight,
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(start = 32.dp, bottom = 8.dp)
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow workouts to form supersets and display existing partner info
- add pushpin action in exercise item for superset selection
- bottom sheet to choose or remove superset partner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c910e710832ab61869ef1ccf4099