### PR TITLE
feat: sectioned LineEditor with bottom sheet

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Exercise.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Exercise.kt
@@ -6,5 +6,6 @@ data class Exercise(
     val sets: Int,
     val repsOrDuration: String,
     val prGoal: Int? = null,
-    val note: String = ""
+    val note: String = "",
+    val section: String = ""
 )


### PR DESCRIPTION
## Summary
- allow exercises to be tagged with a section
- add Create Section bottom sheet in LineEditorPage
- render exercises in SectionWrapper per section with reordering
- show new exercises in an Unassigned section and support dragging between sections
- fix drag-and-drop imports and typed drop handlers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e5078e64832ab2a4b3e0739b56c3