### PR TITLE
Restore drag-and-drop functionality with Compose API

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -20,9 +20,9 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import android.content.ClipData
-import androidx.compose.foundation.draganddrop.DragAndDropTransferData
-import androidx.compose.foundation.draganddrop.dragAndDropSource
-import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import com.example.mygymapp.ui.util.DragAndDropTransferData
+import com.example.mygymapp.ui.util.dragAndDropSource
+import com.example.mygymapp.ui.util.dragAndDropTarget
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -381,11 +381,15 @@ fun LineEditorPage(
                             ) {
                                 val reorderState = rememberReorderableLazyListState(
                                     onMove = { from, to ->
-                                        val fromItem = unassignedItems[from.index]
-                                        val toItem = unassignedItems[to.index]
+                                        val fromItem = unassignedItems.getOrNull(from.index)
+                                            ?: return@rememberReorderableLazyListState
+                                        val toItem = unassignedItems.getOrNull(to.index)
+                                            ?: return@rememberReorderableLazyListState
                                         val fromIdx = selectedExercises.indexOf(fromItem)
                                         val toIdx = selectedExercises.indexOf(toItem)
-                                        selectedExercises.move(fromIdx, toIdx)
+                                        if (fromIdx >= 0 && toIdx >= 0) {
+                                            selectedExercises.move(fromIdx, toIdx)
+                                        }
                                     }
                                 )
                                 LazyColumn(

--- a/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
@@ -1,0 +1,51 @@
+package com.example.mygymapp.ui.util
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.draganddrop.dragAndDropSource as foundationDragAndDropSource
+import androidx.compose.foundation.draganddrop.dragAndDropTarget as foundationDragAndDropTarget
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.input.pointer.PointerEventPass
+
+/**
+ * Compatibility layer adapting the old drag-and-drop helpers used in the
+ * project to the new Compose drag-and-drop APIs. These wrappers delegate to the
+ * official implementations so existing call sites continue to work without
+ * rewriting call sites.
+ */
+
+// Expose the new TransferData type under the legacy name
+typealias DragAndDropTransferData = androidx.compose.ui.draganddrop.DragAndDropTransferData
+
+// Adapter for the old dataProvider signature
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.dragAndDropSource(
+    dataProvider: () -> DragAndDropTransferData
+): Modifier = foundationDragAndDropSource {
+    awaitEachGesture {
+        val down = awaitFirstDown(pass = PointerEventPass.Initial)
+        val longPress = awaitLongPressOrCancellation(down.id)
+        if (longPress != null) {
+            startTransfer(dataProvider())
+        }
+    }
+}
+
+// Adapter for the old onDrop/shouldStartDragAndDrop signature
+@OptIn(ExperimentalFoundationApi::class)
+fun Modifier.dragAndDropTarget(
+    shouldStartDragAndDrop: () -> Boolean,
+    onDrop: (DragAndDropTransferData) -> Boolean
+): Modifier = foundationDragAndDropTarget(
+    shouldStartDragAndDrop = { _: DragAndDropEvent -> shouldStartDragAndDrop() },
+    target = object : DragAndDropTarget {
+        override fun onDrop(event: DragAndDropEvent): Boolean {
+            val data = event as? DragAndDropTransferData ?: return false
+            return onDrop(data)
+        }
+    }
+)


### PR DESCRIPTION
## Summary
- remove reference to nonexistent `dragAndDropTransferData` helper and forward drop events with a safe cast

## Testing
- `./gradlew --no-daemon -q test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68921382fb2c832a8ae68aa80d6e1c3f