### PR TITLE
Restore drag-and-drop functionality with Compose API

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -20,9 +20,9 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import android.content.ClipData
-import androidx.compose.foundation.draganddrop.DragAndDropTransferData
-import androidx.compose.foundation.draganddrop.dragAndDropSource
-import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import com.example.mygymapp.ui.util.DragAndDropTransferData
+import com.example.mygymapp.ui.util.dragAndDropSource
+import com.example.mygymapp.ui.util.dragAndDropTarget
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -381,11 +381,15 @@ fun LineEditorPage(
                             ) {
                                 val reorderState = rememberReorderableLazyListState(
                                     onMove = { from, to ->
-                                        val fromItem = unassignedItems[from.index]
-                                        val toItem = unassignedItems[to.index]
+                                        val fromItem = unassignedItems.getOrNull(from.index)
+                                            ?: return@rememberReorderableLazyListState
+                                        val toItem = unassignedItems.getOrNull(to.index)
+                                            ?: return@rememberReorderableLazyListState
                                         val fromIdx = selectedExercises.indexOf(fromItem)
                                         val toIdx = selectedExercises.indexOf(toItem)
-                                        selectedExercises.move(fromIdx, toIdx)
+                                        if (fromIdx >= 0 && toIdx >= 0) {
+                                            selectedExercises.move(fromIdx, toIdx)
+                                        }
                                     }
                                 )
                                 LazyColumn(

--- a/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
@@ -1,0 +1,66 @@
+package com.example.mygymapp.ui.util
+
+import android.content.ClipData
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.awaitPointerEventScope
+
+/**
+ * Simplified drag-and-drop compatibility layer that recreates the legacy
+ * helpers used throughout the app without relying on the newer experimental
+ * Compose drag-and-drop APIs. A global in-memory transfer is used to bridge
+ * sources and targets.
+ */
+
+/** Data container matching the older API surface. */
+data class DragAndDropTransferData(val clipData: ClipData? = null)
+
+private object DragAndDropState {
+    var transferData: DragAndDropTransferData? = null
+}
+
+/**
+ * Start a drag session after a long press. The provided [dataProvider] is
+ * invoked once the gesture is confirmed and remains available until the
+ * pointer is released.
+ */
+fun Modifier.dragAndDropSource(
+    dataProvider: () -> DragAndDropTransferData
+): Modifier = pointerInput(Unit) {
+    awaitEachGesture {
+        val down = awaitFirstDown()
+        val longPress = awaitLongPressOrCancellation(down.id)
+        if (longPress != null) {
+            DragAndDropState.transferData = dataProvider()
+            waitForUpOrCancellation()
+            DragAndDropState.transferData = null
+        }
+    }
+}
+
+/**
+ * Invoke [onDrop] when a pointer is released over this target while a drag
+ * session is active. The [shouldStartDragAndDrop] callback mirrors the legacy
+ * API and allows callers to veto drops.
+ */
+fun Modifier.dragAndDropTarget(
+    shouldStartDragAndDrop: () -> Boolean,
+    onDrop: (DragAndDropTransferData) -> Boolean
+): Modifier = pointerInput(Unit) {
+    awaitPointerEventScope {
+        while (true) {
+            val event = awaitPointerEvent()
+            val data = DragAndDropState.transferData
+            if (data != null && shouldStartDragAndDrop() &&
+                event.changes.any { it.changedToUpIgnoreConsumed() }) {
+                onDrop(data)
+                DragAndDropState.transferData = null
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove reference to nonexistent `dragAndDropTransferData` helper and forward drop events with a safe cast
- replace stub drag-and-drop layer with a pointer-driven implementation that long-presses to start a drag, stores the transfer data globally, and delivers it to targets on pointer release

## Testing
- `./gradlew --no-daemon -q test` *(fails: SDK location not found)*
- `./gradlew -q test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68921382fb2c832a8ae68aa80d6e1c3f