### PR TITLE
Polish custom drag-and-drop handling for exercise reordering

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -20,9 +20,9 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import android.content.ClipData
-import androidx.compose.foundation.draganddrop.DragAndDropTransferData
-import androidx.compose.foundation.draganddrop.dragAndDropSource
-import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import com.example.mygymapp.ui.util.DragAndDropTransferData
+import com.example.mygymapp.ui.util.dragAndDropSource
+import com.example.mygymapp.ui.util.dragAndDropTarget
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -381,11 +381,15 @@ fun LineEditorPage(
                             ) {
                                 val reorderState = rememberReorderableLazyListState(
                                     onMove = { from, to ->
-                                        val fromItem = unassignedItems[from.index]
-                                        val toItem = unassignedItems[to.index]
+                                        val fromItem = unassignedItems.getOrNull(from.index)
+                                            ?: return@rememberReorderableLazyListState
+                                        val toItem = unassignedItems.getOrNull(to.index)
+                                            ?: return@rememberReorderableLazyListState
                                         val fromIdx = selectedExercises.indexOf(fromItem)
                                         val toIdx = selectedExercises.indexOf(toItem)
-                                        selectedExercises.move(fromIdx, toIdx)
+                                        if (fromIdx >= 0 && toIdx >= 0) {
+                                            selectedExercises.move(fromIdx, toIdx)
+                                        }
                                     }
                                 )
                                 LazyColumn(

--- a/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
@@ -1,0 +1,79 @@
+package com.example.mygymapp.ui.util
+
+import android.content.ClipData
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.awaitPointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.yield
+
+/**
+ * Simplified drag-and-drop compatibility layer that recreates the legacy
+ * helpers used throughout the app without relying on the newer experimental
+ * Compose drag-and-drop APIs. A global in-memory transfer is used to bridge
+ * sources and targets.
+ */
+
+/** Data container matching the older API surface. */
+data class DragAndDropTransferData(val clipData: ClipData? = null)
+
+private data class DragSession(
+    val data: DragAndDropTransferData,
+    val pointerId: PointerId
+)
+
+private object DragAndDropState {
+    var session: DragSession? = null
+}
+
+/**
+ * Start a drag session after a long press. The provided [dataProvider] is
+ * invoked once the gesture is confirmed and remains available until the
+ * pointer is released.
+ */
+fun Modifier.dragAndDropSource(
+    dataProvider: () -> DragAndDropTransferData
+): Modifier = pointerInput(Unit) {
+    awaitEachGesture {
+        val down = awaitFirstDown()
+        val longPress = awaitLongPressOrCancellation(down.id)
+        if (longPress != null) {
+            val session = DragSession(dataProvider(), longPress.id)
+            DragAndDropState.session = session
+            waitForUpOrCancellation()
+            // Yield to allow targets to process the up event before clearing.
+            yield()
+            if (DragAndDropState.session === session) {
+                DragAndDropState.session = null
+            }
+        }
+    }
+}
+
+/**
+ * Invoke [onDrop] when a pointer is released over this target while a drag
+ * session is active. The [shouldStartDragAndDrop] callback mirrors the legacy
+ * API and allows callers to veto drops.
+ */
+fun Modifier.dragAndDropTarget(
+    shouldStartDragAndDrop: () -> Boolean,
+    onDrop: (DragAndDropTransferData) -> Boolean
+): Modifier = pointerInput(Unit) {
+    while (true) {
+        val event = awaitPointerEvent()
+        val session = DragAndDropState.session
+        if (session != null && shouldStartDragAndDrop()) {
+            val change = event.changes.find {
+                it.id == session.pointerId && it.changedToUpIgnoreConsumed()
+            }
+            if (change != null && onDrop(session.data)) {
+                DragAndDropState.session = null
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track active drag pointer and transfer data in a shared session object
- yield and verify session before clearing to avoid races when dropping
- poll pointer events directly in drag targets to avoid removed `awaitPointerEventScope`

## Testing
- `./gradlew -q test` *(fails: SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68921382fb2c832a8ae68aa80d6e1c3f