### PR TITLE
Refine drag-and-drop pointer handling

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
@@ -7,10 +7,9 @@ import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.awaitPointerEvent
 import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.awaitPointerEventScope
-import kotlinx.coroutines.yield
 
 /**
  * Simplified drag-and-drop compatibility layer that recreates the legacy
@@ -46,8 +45,8 @@ fun Modifier.dragAndDropSource(
             val session = DragSession(dataProvider(), longPress.id)
             DragAndDropState.session = session
             waitForUpOrCancellation()
-            // Yield to allow targets to process the up event before clearing.
-            yield()
+            // Await one more event so targets can observe the up event
+            awaitPointerEvent()
             if (DragAndDropState.session === session) {
                 DragAndDropState.session = null
             }
@@ -63,18 +62,16 @@ fun Modifier.dragAndDropSource(
 fun Modifier.dragAndDropTarget(
     shouldStartDragAndDrop: () -> Boolean,
     onDrop: (DragAndDropTransferData) -> Boolean
-): Modifier = pointerInput(Unit) {
-    awaitPointerEventScope {
-        while (true) {
-            val event = awaitPointerEvent()
-            val session = DragAndDropState.session
-            if (session != null && shouldStartDragAndDrop()) {
-                val change = event.changes.find {
-                    it.id == session.pointerId && it.changedToUpIgnoreConsumed()
-                }
-                if (change != null && onDrop(session.data)) {
-                    DragAndDropState.session = null
-                }
+    ): Modifier = pointerInput(Unit) {
+    while (true) {
+        val event = awaitPointerEvent()
+        val session = DragAndDropState.session
+        if (session != null && shouldStartDragAndDrop()) {
+            val change = event.changes.find {
+                it.id == session.pointerId && it.changedToUpIgnoreConsumed()
+            }
+            if (change != null && onDrop(session.data)) {
+                DragAndDropState.session = null
             }
         }
     }


### PR DESCRIPTION
## Summary
- keep drag sessions active until pointer release using existing pointer event scope
- process drop targets in a continuous pointer loop without extra scopes

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689249f40758832ab0fc26b6e9b41994