### PR TITLE
Fix downward reordering in exercise list

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/util/CollectionUtils.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/util/CollectionUtils.kt
@@ -6,5 +6,5 @@ package com.example.mygymapp.ui.util
 fun <T> MutableList<T>.move(from: Int, to: Int) {
     if (from == to) return
     val item = removeAt(from)
-    add(if (to > from) to - 1 else to, item)
+    add(to, item)
 }


### PR DESCRIPTION
## Summary
- fix list move helper so dropping items downward works correctly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689249f40758832ab0fc26b6e9b41994