### PR TITLE
Add central design system for poetic training app

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/theme/DesignSystem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/DesignSystem.kt
@@ -1,0 +1,64 @@
+package com.example.mygymapp.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import com.example.mygymapp.R
+
+object AppColors {
+    val Paper = Color(0xFFF3E5AB)           // warmes Papier
+    val DeepText = Color(0xFF2E2E2E)        // fast schwarz, wie Tinte
+    val SubtleText = Color(0xFF4B3B2F)      // ruhiger, bräunlicher Text
+    val ButtonGreen = Color(0xFF3B5F47)     // moosgrüner Button
+    val ErrorMaroon = Color(0xFF8B0000)     // dunkles Blutrot
+    val SectionLine = Color(0xFFAA9870)     // feine Bleistiftlinie
+    val SelectedChip = Color(0xFFD5C5AA)    // ruhiger Beige-Ton für Auswahl
+}
+
+object AppTypography {
+    val GaeguRegular = FontFamily(Font(R.font.gaegu_regular))
+    val GaeguBold = FontFamily(Font(R.font.gaegu_bold))
+    val GaeguLight = FontFamily(Font(R.font.gaegu_light))
+
+    val Title = TextStyle(
+        fontFamily = GaeguBold,
+        fontSize = 24.sp,
+        color = AppColors.DeepText
+    )
+
+    val Body = TextStyle(
+        fontFamily = GaeguRegular,
+        fontSize = 16.sp,
+        color = AppColors.DeepText
+    )
+
+    val Hint = TextStyle(
+        fontFamily = GaeguLight,
+        fontSize = 14.sp,
+        color = AppColors.SubtleText
+    )
+
+    val Button = TextStyle(
+        fontFamily = GaeguBold,
+        fontSize = 16.sp,
+        color = Color.White
+    )
+}
+
+object AppShapes {
+    val Card = RoundedCornerShape(12.dp)
+    val Button = RoundedCornerShape(8.dp)
+    val Small = RoundedCornerShape(4.dp)
+}
+
+object AppPadding {
+    val Screen = 24.dp
+    val Section = 16.dp
+    val Element = 12.dp
+    val Small = 8.dp
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/theme/MyGymAppTheme.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/MyGymAppTheme.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import com.example.mygymapp.ui.theme.MyGymColorScheme.DarkColors
 import com.example.mygymapp.ui.theme.MyGymColorScheme.LightColors
-import com.example.mygymapp.ui.theme.AppShapes
+import com.example.mygymapp.ui.theme.MyGymShapes
 import com.example.mygymapp.ui.theme.MyGymTypography
 
 @Composable
@@ -14,7 +14,7 @@ fun MyGymAppTheme(content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = colors,
         typography = MyGymTypography,
-        shapes = AppShapes,
+        shapes = MyGymShapes,
         content = content
     )
 }

--- a/app/src/main/java/com/example/mygymapp/ui/theme/Shapes.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/Shapes.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
-val AppShapes = Shapes(
+val MyGymShapes = Shapes(
     small = RoundedCornerShape(8.dp),
     medium = RoundedCornerShape(12.dp),
     large = RoundedCornerShape(0.dp)


### PR DESCRIPTION
## Summary
- Introduce DesignSystem.kt with cohesive color palette, Gaegu-based typography, shape tokens, and padding values inspired by paper and nature.
- Rename existing shape tokens to `MyGymShapes` and adjust theme to avoid naming conflict.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68926473d478832a9d6d32e5895d2fda