### PR TITLE
feat: add Poetic UI components and design demo page

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticCard.kt
@@ -2,20 +2,26 @@ package com.example.mygymapp.ui.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.R
-import androidx.compose.ui.Alignment
+import com.example.mygymapp.ui.theme.AppColors
+import com.example.mygymapp.ui.theme.AppPadding
+import com.example.mygymapp.ui.theme.AppShapes
 
 
 enum class PoeticCardStyle {
@@ -34,24 +40,22 @@ fun PoeticCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 4.dp)
-            .clip(RoundedCornerShape(12.dp)),
-        shape = RoundedCornerShape(12.dp),
+            .padding(horizontal = AppPadding.Small, vertical = 4.dp)
+            .clip(AppShapes.Card),
+        shape = AppShapes.Card,
         elevation = CardDefaults.cardElevation(6.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent)
+        colors = CardDefaults.cardColors(containerColor = AppColors.ButtonGreen)
     ) {
         Box(
             modifier = Modifier
-                .clip(RoundedCornerShape(12.dp))
-                .background(Color(0xFFF5F5DC)) // fallback color
+                .clip(AppShapes.Card)
+                .background(AppColors.ButtonGreen)
         ) {
             // Hintergrundtextur
             Image(
                 painter = painterResource(R.drawable.parchment),
                 contentDescription = null,
-                modifier = Modifier
-                    .matchParentSize(),
-                contentScale = ContentScale.Crop
+                modifier = Modifier.matchParentSize()
             )
 
             // Optionales Eselsohr
@@ -80,7 +84,7 @@ fun PoeticCard(
 
             Column(
                 modifier = Modifier
-                    .padding(16.dp)
+                    .padding(AppPadding.Element)
             ) {
                 content()
             }

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticDivider.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticDivider.kt
@@ -1,0 +1,55 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.mygymapp.ui.theme.AppColors
+import com.example.mygymapp.ui.theme.AppPadding
+import com.example.mygymapp.ui.theme.AppTypography
+
+@Composable
+fun PoeticDivider(
+    modifier: Modifier = Modifier,
+    paddingStart: Dp = AppPadding.Screen,
+    paddingEnd: Dp = AppPadding.Screen,
+    centerText: String? = null
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                start = paddingStart,
+                end = paddingEnd,
+                top = AppPadding.Element,
+                bottom = AppPadding.Element
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Divider(
+            color = AppColors.SectionLine,
+            thickness = 1.dp,
+            modifier = Modifier.weight(1f)
+        )
+
+        if (centerText != null) {
+            Spacer(Modifier.width(AppPadding.Small))
+            Text(centerText, style = AppTypography.Body)
+            Spacer(Modifier.width(AppPadding.Small))
+            Divider(
+                color = AppColors.SectionLine,
+                thickness = 1.dp,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticTextField.kt
@@ -1,0 +1,62 @@
+package com.example.mygymapp.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.draw.clip
+import com.example.mygymapp.ui.theme.AppColors
+import com.example.mygymapp.ui.theme.AppPadding
+import com.example.mygymapp.ui.theme.AppShapes
+import com.example.mygymapp.ui.theme.AppTypography
+
+/**
+ * A calm text field resembling a handwritten note area.
+ */
+@Composable
+fun PoeticTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    hint: String = "What was quiet? What was loud?",
+    textStyle: TextStyle = AppTypography.Body,
+    hintStyle: TextStyle = AppTypography.Hint,
+    minLines: Int = 4,
+    maxLines: Int = 12
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(AppShapes.Small)
+            .background(AppColors.Paper)
+            .padding(AppPadding.Element)
+    ) {
+        if (value.isEmpty()) {
+            Text(
+                text = hint,
+                style = hintStyle,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = textStyle,
+            cursorBrush = SolidColor(AppColors.DeepText),
+            maxLines = maxLines,
+            modifier = Modifier
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = (minLines * 24).dp)
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/mygymapp/ui/pages/DesignDemoPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/DesignDemoPage.kt
@@ -1,0 +1,99 @@
+package com.example.mygymapp.ui.pages
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.example.mygymapp.ui.components.LinedTextField
+import com.example.mygymapp.ui.components.PoeticCard
+import com.example.mygymapp.ui.components.PoeticCardStyle
+import com.example.mygymapp.ui.components.PoeticDivider
+import com.example.mygymapp.ui.components.PoeticTextField
+import com.example.mygymapp.ui.theme.AppColors
+import com.example.mygymapp.ui.theme.AppPadding
+import com.example.mygymapp.ui.theme.AppTypography
+
+/**
+ * A showcase page to preview poetic UI components and styling.
+ */
+@Composable
+fun DesignDemoPage() {
+    var text by remember { mutableStateOf("") }
+    var notes by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(AppPadding.Screen)
+    ) {
+        Text("\ud83d\udcd8 Design Demo", style = AppTypography.Title)
+
+        Spacer(Modifier.height(AppPadding.Section))
+        PoeticDivider(centerText = "Poetic Card")
+
+        PoeticCard(style = PoeticCardStyle.ESELOHR) {
+            Text("Today's Focus", style = AppTypography.Title)
+            Text("Push \u00b7 Calm \u00b7 Core", style = AppTypography.Body)
+        }
+
+        Spacer(Modifier.height(AppPadding.Section))
+        PoeticDivider(centerText = "Poetic Text Field")
+
+        PoeticTextField(
+            value = text,
+            onValueChange = { text = it },
+            hint = "What moved through you today?"
+        )
+
+        Spacer(Modifier.height(AppPadding.Section))
+        PoeticDivider(centerText = "Lined Text Field")
+
+        LinedTextField(
+            value = notes,
+            onValueChange = { notes = it },
+            hint = "Write here like in a lined notebook..."
+        )
+
+        Spacer(Modifier.height(AppPadding.Section))
+        PoeticDivider(centerText = "Buttons & Style")
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Button(
+                onClick = {},
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AppColors.ButtonGreen
+                )
+            ) {
+                Text("Confirm", style = AppTypography.Button)
+            }
+
+            Button(
+                onClick = {},
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = AppColors.ErrorMaroon
+                )
+            ) {
+                Text("Cancel", style = AppTypography.Button)
+            }
+        }
+
+        Spacer(Modifier.height(AppPadding.Section * 2))
+    }
+}
+


### PR DESCRIPTION
## Summary
- style PoeticCard with optional journal-like accents
- add PoeticDivider for subtle section separation
- introduce PoeticTextField for handwritten-style note input
- add DesignDemoPage showcasing poetic components for review

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68926c353ce0832a944768fa436ef004