### PR TITLE
Refactor LineEditorPage to use poetic components

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -41,12 +40,7 @@ fun ReorderableExerciseItem(
     dragHandle: @Composable () -> Unit,
     supersetPartnerIndices: List<Int> = emptyList()
 ) {
-    Surface(
-        shape = RoundedCornerShape(12.dp),
-        color = Color(0xFFF5F5DC),
-        tonalElevation = 2.dp,
-        modifier = modifier
-    ) {
+    PoeticCard(modifier = modifier) {
         Column {
             Row(
                 modifier = Modifier
@@ -76,7 +70,7 @@ fun ReorderableExerciseItem(
                                 text = "e.g. $it reps",
                                 fontFamily = GaeguLight,
                                 fontSize = 12.sp,
-                                color = Color.Gray
+                                color = Color.Black
                             )
                         }
                     }

--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
@@ -1,13 +1,9 @@
 package com.example.mygymapp.ui.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -23,22 +19,12 @@ fun SectionWrapper(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 12.dp)
-            .shadow(elevation = 4.dp, shape = RoundedCornerShape(16.dp))
-            .background(
-                color = Color(0xFFF5F5DC),
-                shape = RoundedCornerShape(16.dp)
-            )
-            .padding(16.dp)
-    ) {
+    PoeticCard(modifier = modifier.padding(vertical = 12.dp)) {
         Text(
             text = title,
             fontFamily = GaeguBold,
             fontSize = 18.sp,
-            color = Color(0xFF3E2723),
+            color = Color.Black,
             modifier = Modifier.padding(bottom = 12.dp)
         )
 

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DragHandle
@@ -33,6 +32,8 @@ import com.example.mygymapp.ui.components.GaeguButton
 import com.example.mygymapp.ui.components.LinedTextField
 import com.example.mygymapp.ui.components.PaperBackground
 import com.example.mygymapp.ui.components.PoeticBottomSheet
+import com.example.mygymapp.ui.components.PoeticCard
+import com.example.mygymapp.ui.components.PoeticDivider
 import com.example.mygymapp.ui.components.PoeticMultiSelectChips
 import com.example.mygymapp.ui.components.PoeticRadioChips
 import com.example.mygymapp.ui.components.ReorderableExerciseItem
@@ -159,10 +160,13 @@ fun LineEditorPage(
                     "✒ Compose your daily line",
                     fontFamily = GaeguBold,
                     fontSize = 24.sp,
+                    color = Color.Black,
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
 
-                Text("What would you title this day?", fontFamily = GaeguRegular)
+                PoeticDivider()
+
+                Text("What would you title this day?", fontFamily = GaeguRegular, color = Color.Black)
                 LinedTextField(
                     value = title,
                     onValueChange = { title = it },
@@ -170,7 +174,9 @@ fun LineEditorPage(
                     initialLines = 1
                 )
 
-                Text("What kind of movement is this?", fontFamily = GaeguRegular)
+                PoeticDivider()
+
+                Text("What kind of movement is this?", fontFamily = GaeguRegular, color = Color.Black)
                 PoeticMultiSelectChips(
                     options = categoryOptions,
                     selectedItems = selectedCategories,
@@ -180,7 +186,9 @@ fun LineEditorPage(
                     }
                 )
 
-                Text("Which areas are involved?", fontFamily = GaeguRegular)
+                PoeticDivider()
+
+                Text("Which areas are involved?", fontFamily = GaeguRegular, color = Color.Black)
                 PoeticMultiSelectChips(
                     options = muscleOptions,
                     selectedItems = selectedMuscles,
@@ -190,7 +198,9 @@ fun LineEditorPage(
                     }
                 )
 
-                Text("Your notes on this movement", fontFamily = GaeguRegular)
+                PoeticDivider()
+
+                Text("Your notes on this movement", fontFamily = GaeguRegular, color = Color.Black)
                 LinedTextField(
                     value = note,
                     onValueChange = { note = it },
@@ -198,7 +208,9 @@ fun LineEditorPage(
                     initialLines = 3
                 )
 
-                Text("Which movements do you want to add?", fontFamily = GaeguRegular)
+                PoeticDivider()
+
+                Text("Which movements do you want to add?", fontFamily = GaeguRegular, color = Color.Black)
                 val showExerciseSheet = remember { mutableStateOf(false) }
                 val showSectionSheet = remember { mutableStateOf(false) }
                 val exerciseSearch = remember { mutableStateOf("") }
@@ -244,7 +256,7 @@ fun LineEditorPage(
                             "No matching exercises found.",
                             fontFamily = GaeguLight,
                             fontSize = 14.sp,
-                            color = Color.Gray,
+                            color = Color.Black,
                             modifier = Modifier.padding(12.dp)
                         )
                     } else {
@@ -254,7 +266,7 @@ fun LineEditorPage(
                                 .fillMaxWidth()
                         ) {
                             items(filteredExercises) { ex ->
-                                Surface(
+                                PoeticCard(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(vertical = 4.dp)
@@ -272,20 +284,15 @@ fun LineEditorPage(
                                             showExerciseSheet.value = false
                                             exerciseSearch.value = ""
                                             selectedFilter.value = null
-                                        },
-                                    shape = RoundedCornerShape(8.dp),
-                                    color = Color.White,
-                                    contentColor = Color.Black
+                                        }
                                 ) {
-                                    Column(Modifier.padding(12.dp)) {
-                                        Text(ex.name, fontFamily = GaeguRegular, fontSize = 16.sp)
-                                        Text(
-                                            "${ex.muscleGroup.display} · ${ex.category.display}",
-                                            fontFamily = GaeguLight,
-                                            fontSize = 13.sp,
-                                            color = Color.Gray
-                                        )
-                                    }
+                                    Text(ex.name, fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
+                                    Text(
+                                        "${ex.muscleGroup.display} · ${ex.category.display}",
+                                        fontFamily = GaeguLight,
+                                        fontSize = 13.sp,
+                                        color = Color.Black
+                                    )
                                 }
                             }
                         }
@@ -294,7 +301,7 @@ fun LineEditorPage(
 
                 if (selectedExercises.isNotEmpty()) {
                     if (sections.isEmpty()) {
-                        Text("Today's selected movements:", fontFamily = GaeguBold)
+                        Text("Today's selected movements:", fontFamily = GaeguBold, color = Color.Black)
                         val reorderState = rememberReorderableLazyListState(
                             onMove = { from, to ->
                                 selectedExercises.move(from.index, to.index)
@@ -628,6 +635,7 @@ fun LineEditorPage(
                                     Text(
                                         ex.name,
                                         fontFamily = GaeguRegular,
+                                        color = Color.Black,
                                         modifier = Modifier.padding(start = 8.dp)
                                     )
                                 }
@@ -657,11 +665,14 @@ fun LineEditorPage(
                     }
                 }
 
+                PoeticDivider()
 
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                    TextButton(onClick = onCancel) {
-                        Text("Cancel", fontFamily = GaeguRegular, color = Color.Black)
-                    }
+                    GaeguButton(
+                        text = "Cancel",
+                        onClick = onCancel,
+                        textColor = Color.Black
+                    )
                     Spacer(Modifier.width(16.dp))
                     GaeguButton(
                         text = "Create",
@@ -690,7 +701,7 @@ fun LineEditorPage(
                 if (showError) {
                     Text(
                         "Please fill out title and at least one exercise",
-                        color = Color.Red,
+                        color = Color.Black,
                         fontFamily = GaeguRegular
                     )
                 }


### PR DESCRIPTION
## Summary
- swap old Surface layout for PoeticCard in exercise picker
- use GaeguButton instead of TextButton for cancel action
- wrap selected exercises and sections in PoeticCard and ensure all text renders in black
- insert PoeticDivider lines to split major sections in LineEditorPage for clearer separation

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893c07b2460832ab9cea993b8bf68ba