### PR TITLE
Center Line Editor page and refine exercise filtering

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/GaeguButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/GaeguButton.kt
@@ -1,5 +1,6 @@
 package com.example.mygymapp.ui.components
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -14,10 +15,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -31,11 +35,12 @@ fun GaeguButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     font: FontFamily = GaeguBold,
-    backgroundColor: Color = Color(0xFFEDE5D0),
+    gradientColors: List<Color> = listOf(Color(0xFFFFAFBD), Color(0xFFFFC3A0)),
     textColor: Color = Color.Black,
     cornerRadius: Dp = 12.dp,
     elevation: Dp = 2.dp,
-    fontSize: TextUnit = 16.sp
+    fontSize: TextUnit = 16.sp,
+    enabled: Boolean = true
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -44,12 +49,21 @@ fun GaeguButton(
         label = "button-scale"
     )
 
+    val targetColors = if (isPressed) {
+        gradientColors.map { lerp(it, Color.White, 0.2f) }
+    } else gradientColors
+    val startColor by animateColorAsState(targetColors[0], label = "start-color")
+    val endColor by animateColorAsState(targetColors[1], label = "end-color")
+    val brush = Brush.linearGradient(listOf(startColor, endColor))
+
     Box(
         modifier = modifier
             .scale(scale)
             .clip(RoundedCornerShape(cornerRadius))
-            .background(backgroundColor)
+            .background(brush)
+            .alpha(if (enabled) 1f else 0.5f)
             .clickable(
+                enabled = enabled,
                 interactionSource = interactionSource,
                 indication = null, // ⛔ Kein Ripple
                 onClick = onClick

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticMultiSelectChips.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticMultiSelectChips.kt
@@ -3,12 +3,14 @@ package com.example.mygymapp.ui.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
@@ -34,8 +36,8 @@ fun PoeticMultiSelectChips(
     spacing: Dp = 8.dp
 ) {
     FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(spacing),
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(spacing)
     ) {
         options.forEach { option ->

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticRadioChips.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticRadioChips.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
@@ -34,8 +36,8 @@ fun PoeticRadioChips(
     spacing: Dp = 8.dp
 ) {
     FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(spacing),
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(spacing)
     ) {
         options.forEach { option ->

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -38,6 +38,7 @@ import com.example.mygymapp.ui.components.PoeticMultiSelectChips
 import com.example.mygymapp.ui.components.PoeticRadioChips
 import com.example.mygymapp.ui.components.ReorderableExerciseItem
 import com.example.mygymapp.ui.components.SectionWrapper
+import com.example.mygymapp.ui.components.WaxSealButton
 import com.example.mygymapp.ui.util.move
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
@@ -77,7 +78,7 @@ fun LineEditorPage(
 
     val categoryOptions =
         listOf("💪 Strength", "🔥 Cardio", "🌱 Warmup", "🧘 Flexibility", "🌀 Recovery")
-    val muscleOptions = listOf("Back", "Legs", "Core", "Shoulders", "Chest", "Full Body")
+    val muscleOptions = listOf("Back", "Legs", "Core", "Shoulders", "Chest", "Arms", "Full Body")
 
     val selectedCategories = remember {
         mutableStateListOf<String>().apply { initial?.category?.split(",")?.let { addAll(it) } }
@@ -154,7 +155,8 @@ fun LineEditorPage(
                     .verticalScroll(rememberScrollState())
                     .systemBarsPadding()
                     .padding(24.dp),
-                verticalArrangement = Arrangement.spacedBy(20.dp)
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
                     "✒ Compose your daily line",
@@ -169,7 +171,8 @@ fun LineEditorPage(
                     value = title,
                     onValueChange = { title = it },
                     hint = "A poetic title...",
-                    initialLines = 1
+                    initialLines = 1,
+                    modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
                 )
                 PoeticDivider(centerText = "What kind of movement is this?")
                 PoeticMultiSelectChips(
@@ -178,7 +181,8 @@ fun LineEditorPage(
                     onSelectionChange = {
                         selectedCategories.clear()
                         selectedCategories.addAll(it)
-                    }
+                    },
+                    modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
                 )
                 PoeticDivider(centerText = "Which areas are involved?")
                 PoeticMultiSelectChips(
@@ -187,30 +191,46 @@ fun LineEditorPage(
                     onSelectionChange = {
                         selectedMuscles.clear()
                         selectedMuscles.addAll(it)
-                    }
+                    },
+                    modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
                 )
                 PoeticDivider(centerText = "Your notes on this movement")
                 LinedTextField(
                     value = note,
                     onValueChange = { note = it },
                     hint = "Write your thoughts here...",
-                    initialLines = 3
+                    initialLines = 3,
+                    modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
                 )
                 PoeticDivider(centerText = "Which movements do you want to add?")
                 val showExerciseSheet = remember { mutableStateOf(false) }
                 val showSectionSheet = remember { mutableStateOf(false) }
                 val exerciseSearch = remember { mutableStateOf("") }
-                val filterMuscles = selectedMuscles.ifEmpty {
-                    allExercises.map { it.muscleGroup.display }.distinct()
+                val filterOptions by remember {
+                    derivedStateOf {
+                        val base = listOf("All", "Full Body")
+                        if (selectedMuscles.isEmpty()) base else (base + selectedMuscles).distinct()
+                    }
                 }
                 val selectedFilter = remember { mutableStateOf<String?>(null) }
+                LaunchedEffect(filterOptions) {
+                    if (selectedFilter.value !in filterOptions) selectedFilter.value = null
+                }
 
-                val filteredExercises = allExercises.filter {
-                    val matchesFilter =
-                        selectedFilter.value == null || it.muscleGroup.display == selectedFilter.value
-                    val matchesSearch = exerciseSearch.value.isBlank() ||
-                            it.name.contains(exerciseSearch.value, ignoreCase = true)
-                    matchesFilter && matchesSearch
+                val filteredExercises by remember(
+                    exerciseSearch.value,
+                    selectedFilter.value,
+                    allExercises
+                ) {
+                    derivedStateOf {
+                        val query = exerciseSearch.value.trim().lowercase()
+                        allExercises.filter { ex ->
+                            val matchesFilter =
+                                selectedFilter.value == null || ex.muscleGroup.display == selectedFilter.value
+                            val matchesSearch = query.isEmpty() || ex.name.lowercase().contains(query)
+                            matchesFilter && matchesSearch
+                        }
+                    }
                 }
 
                 GaeguButton(
@@ -227,14 +247,15 @@ fun LineEditorPage(
                         value = exerciseSearch.value,
                         onValueChange = { exerciseSearch.value = it },
                         hint = "Search exercises",
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally),
                         initialLines = 1
                     )
                     Spacer(Modifier.height(12.dp))
                     PoeticRadioChips(
-                        options = listOf("All") + filterMuscles,
+                        options = filterOptions,
                         selected = selectedFilter.value ?: "All",
-                        onSelected = { selectedFilter.value = if (it == "All") null else it }
+                        onSelected = { selectedFilter.value = if (it == "All") null else it },
+                        modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
                     )
                     Spacer(Modifier.height(12.dp))
                     if (filteredExercises.isEmpty()) {
@@ -251,7 +272,7 @@ fun LineEditorPage(
                                 .heightIn(max = 320.dp)
                                 .fillMaxWidth()
                         ) {
-                            items(filteredExercises) { ex ->
+                            items(filteredExercises, key = { it.id }) { ex ->
                                 PoeticCard(
                                     modifier = Modifier
                                         .fillMaxWidth()
@@ -350,7 +371,9 @@ fun LineEditorPage(
                             }
                         }
                     } else {
-                        val unassignedItems = selectedExercises.filter { it.section.isBlank() }
+                        val unassignedItems by remember(selectedExercises) {
+                            derivedStateOf { selectedExercises.filter { it.section.isBlank() } }
+                        }
                         if (unassignedItems.isNotEmpty()) {
                             SectionWrapper(
                                 title = "Unassigned",
@@ -457,7 +480,9 @@ fun LineEditorPage(
                             }
                         }
                         sections.forEach { sectionName ->
-                            val sectionItems = selectedExercises.filter { it.section == sectionName }
+                            val sectionItems by remember(selectedExercises, sectionName) {
+                                derivedStateOf { selectedExercises.filter { it.section == sectionName } }
+                            }
                             if (sectionItems.isNotEmpty()) {
                                 SectionWrapper(
                                     title = sectionName,
@@ -586,7 +611,8 @@ fun LineEditorPage(
                         PoeticRadioChips(
                             options = listOf("Warm-up", "Workout", "Cooldown", "Custom"),
                             selected = selectedOption ?: "",
-                            onSelected = { selectedOption = it }
+                            onSelected = { selectedOption = it },
+                            modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally)
                         )
 
                         if (selectedOption == "Custom") {
@@ -595,7 +621,7 @@ fun LineEditorPage(
                                 value = customName,
                                 onValueChange = { customName = it },
                                 hint = "Section name",
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally),
                                 initialLines = 1
                             )
                         }
@@ -653,19 +679,19 @@ fun LineEditorPage(
 
                 PoeticDivider()
 
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                Box(modifier = Modifier.fillMaxWidth()) {
                     GaeguButton(
                         text = "Cancel",
                         onClick = onCancel,
-                        textColor = Color.Black
+                        textColor = Color.Black,
+                        modifier = Modifier.align(Alignment.CenterStart)
                     )
-                    Spacer(Modifier.width(16.dp))
-                    GaeguButton(
-                        text = "Create",
+                    WaxSealButton(
+                        label = "Create",
                         onClick = {
                             if (title.isBlank() || selectedExercises.isEmpty()) {
                                 showError = true
-                                return@GaeguButton
+                                return@WaxSealButton
                             }
                             val newLine = Line(
                                 id = initial?.id ?: System.currentTimeMillis(),
@@ -680,7 +706,7 @@ fun LineEditorPage(
                             )
                             onSave(newLine)
                         },
-                        textColor = Color.Black
+                        modifier = Modifier.align(Alignment.Center)
                     )
                 }
 


### PR DESCRIPTION
## Summary
- Add "Arms" before "Full Body" in muscle group chips
- Always provide keyed list in exercise modal for smoother filtering
- Trim and lowercase search text to avoid repeated allocations during scroll
- Show only "All" and "Full Body" until areas are selected in exercise sheet
- Recompute exercise filter options when selected areas change

## Testing
- `./gradlew test` *(fails: SDK location not found; install Android SDK and accept licenses)*

------
https://chatgpt.com/codex/tasks/task_e_6894725c23c8832a9bb0fb54e3e9edc4