### PR TITLE
Center Line Editor page, refine exercise filtering, and persist form state

### DIFF
--- a/app/src/main/java/com/example/mygymapp/model/Exercise.kt
+++ b/app/src/main/java/com/example/mygymapp/model/Exercise.kt
@@ -1,5 +1,7 @@
 package com.example.mygymapp.model
 
+import java.io.Serializable
+
 data class Exercise(
     val id: Long,
     val name: String,
@@ -8,4 +10,4 @@ data class Exercise(
     val prGoal: Int? = null,
     val note: String = "",
     val section: String = ""
-)
+) : Serializable

--- a/app/src/main/java/com/example/mygymapp/ui/components/GaeguButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/GaeguButton.kt
@@ -1,5 +1,6 @@
 package com.example.mygymapp.ui.components
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -14,10 +15,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -31,11 +35,12 @@ fun GaeguButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     font: FontFamily = GaeguBold,
-    backgroundColor: Color = Color(0xFFEDE5D0),
+    gradientColors: List<Color> = listOf(Color(0xFFFFAFBD), Color(0xFFFFC3A0)),
     textColor: Color = Color.Black,
     cornerRadius: Dp = 12.dp,
     elevation: Dp = 2.dp,
-    fontSize: TextUnit = 16.sp
+    fontSize: TextUnit = 16.sp,
+    enabled: Boolean = true
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -44,12 +49,21 @@ fun GaeguButton(
         label = "button-scale"
     )
 
+    val targetColors = if (isPressed) {
+        gradientColors.map { lerp(it, Color.White, 0.2f) }
+    } else gradientColors
+    val startColor by animateColorAsState(targetColors[0], label = "start-color")
+    val endColor by animateColorAsState(targetColors[1], label = "end-color")
+    val brush = Brush.linearGradient(listOf(startColor, endColor))
+
     Box(
         modifier = modifier
             .scale(scale)
             .clip(RoundedCornerShape(cornerRadius))
-            .background(backgroundColor)
+            .background(brush)
+            .alpha(if (enabled) 1f else 0.5f)
             .clickable(
+                enabled = enabled,
                 interactionSource = interactionSource,
                 indication = null, // ⛔ Kein Ripple
                 onClick = onClick

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticMultiSelectChips.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticMultiSelectChips.kt
@@ -3,12 +3,14 @@ package com.example.mygymapp.ui.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
@@ -34,8 +36,8 @@ fun PoeticMultiSelectChips(
     spacing: Dp = 8.dp
 ) {
     FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(spacing),
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(spacing)
     ) {
         options.forEach { option ->

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticRadioChips.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticRadioChips.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
@@ -34,8 +36,8 @@ fun PoeticRadioChips(
     spacing: Dp = 8.dp
 ) {
     FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(spacing),
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(spacing)
     ) {
         options.forEach { option ->

--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -1,8 +1,8 @@
 package com.example.mygymapp.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Checkbox
@@ -13,9 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.foundation.shape.RoundedCornerShape
 import com.example.mygymapp.model.Exercise as LineExercise
 import com.example.mygymapp.ui.pages.GaeguBold
 import com.example.mygymapp.ui.pages.GaeguLight
@@ -40,88 +40,100 @@ fun ReorderableExerciseItem(
     dragHandle: @Composable () -> Unit,
     supersetPartnerIndices: List<Int> = emptyList()
 ) {
-    PoeticCard(modifier = modifier) {
-        Column {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                // Index & Name
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = "${index + 1}.",
-                        fontFamily = GaeguBold,
-                        fontSize = 16.sp,
-                        color = Color.Black,
-                        modifier = Modifier.padding(end = 8.dp)
-                    )
-                    Column {
-                        Text(
-                            text = exercise.name,
-                            fontFamily = GaeguRegular,
-                            fontSize = 16.sp,
-                            color = Color.Black
-                        )
-                        exercise.repsOrDuration?.let {
-                            Text(
-                                text = "e.g. $it reps",
-                                fontFamily = GaeguLight,
-                                fontSize = 12.sp,
-                                color = Color.Black
-                            )
-                        }
-                    }
-                }
+    val indices = (listOf(index) + supersetPartnerIndices).sorted()
+    val isSuperset = supersetPartnerIndices.isNotEmpty()
+    val isFirst = isSuperset && index == indices.first()
+    val isLast = isSuperset && index == indices.last()
 
-                // Actions
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onRemove) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete",
-                            tint = Color.Red
-                        )
-                    }
-                    Checkbox(
-                        checked = isSupersetSelected,
-                        onCheckedChange = onSupersetSelectedChange
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isSuperset) {
+            Box(
+                modifier = Modifier
+                    .width(16.dp)
+                    .fillMaxHeight()
+            ) {
+                Canvas(modifier = Modifier.fillMaxSize()) {
+                    val stroke = 2.dp.toPx()
+                    val centerX = size.width / 2f
+                    val startY = if (isFirst) size.height / 2f else 0f
+                    val endY = if (isLast) size.height / 2f else size.height
+                    drawLine(
+                        color = Color.Black,
+                        start = Offset(centerX, startY),
+                        end = Offset(centerX, endY),
+                        strokeWidth = stroke
                     )
-                    dragHandle()
+                    drawLine(
+                        color = Color.Black,
+                        start = Offset(centerX, size.height / 2f),
+                        end = Offset(size.width, size.height / 2f),
+                        strokeWidth = stroke
+                    )
                 }
             }
+        } else {
+            Spacer(Modifier.width(16.dp))
+        }
 
-            if (supersetPartnerIndices.isNotEmpty()) {
+        PoeticCard(
+            modifier = Modifier
+                .padding(vertical = 4.dp)
+                .weight(1f)
+        ) {
+            Column {
                 Row(
                     modifier = Modifier
-                        .padding(start = 32.dp, bottom = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    val indices = (listOf(index) + supersetPartnerIndices).sorted()
-                    indices.forEachIndexed { i, idx ->
-                        Box(
-                            modifier = Modifier
-                                .size(20.dp)
-                                .border(1.dp, Color.Black, RoundedCornerShape(4.dp)),
-                            contentAlignment = Alignment.Center
-                        ) {
+                    // Index & Name
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = "${index + 1}.",
+                            fontFamily = GaeguBold,
+                            fontSize = 16.sp,
+                            color = Color.Black,
+                            modifier = Modifier.padding(end = 8.dp)
+                        )
+                        Column {
                             Text(
-                                text = "${idx + 1}",
-                                fontFamily = GaeguLight,
-                                fontSize = 12.sp,
+                                text = exercise.name,
+                                fontFamily = GaeguRegular,
+                                fontSize = 16.sp,
                                 color = Color.Black
                             )
+                            exercise.repsOrDuration?.let {
+                                Text(
+                                    text = "e.g. $it reps",
+                                    fontFamily = GaeguLight,
+                                    fontSize = 12.sp,
+                                    color = Color.Black
+                                )
+                            }
                         }
-                        if (i < indices.lastIndex) {
-                            Box(
-                                modifier = Modifier
-                                    .width(12.dp)
-                                    .height(1.dp)
-                                    .background(Color.Black)
+                    }
+
+                    // Actions
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = onRemove) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete",
+                                tint = Color.Red
                             )
                         }
+                        Checkbox(
+                            checked = isSupersetSelected,
+                            onCheckedChange = onSupersetSelectedChange
+                        )
+                        dragHandle()
                     }
                 }
             }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ArchiveNavigation.kt
@@ -45,8 +45,19 @@ fun ArchiveNavigation(onNavigateToEntry: () -> Unit = {}) {
             val editIdArg = backStackEntry.arguments?.getLong("editId")?.takeIf { it != -1L }
             MovementEntryPage(navController = navController, editId = editIdArg, userCategories = com.example.mygymapp.model.CustomCategories.list)
         }
-        composable("movement_editor") {
-            MovementEntryPage(navController = navController, userCategories = com.example.mygymapp.model.CustomCategories.list)
+        composable(
+            route = "movement_editor?name={name}",
+            arguments = listOf(navArgument("name") {
+                type = NavType.StringType
+                defaultValue = ""
+            })
+        ) { backStackEntry ->
+            val prefillName = backStackEntry.arguments?.getString("name")?.takeIf { it.isNotBlank() }
+            MovementEntryPage(
+                navController = navController,
+                initialName = prefillName,
+                userCategories = com.example.mygymapp.model.CustomCategories.list
+            )
         }
         composable("register_editor") {
             RegisterManagementPage()

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -30,6 +30,13 @@ fun LineParagraphPage(
     var editingLine by remember { mutableStateOf<Line?>(null) }
     var showLineEditor by remember { mutableStateOf(false) }
 
+    // When coming back from movement creation, reopen the line editor
+    val savedState = navController.currentBackStackEntry?.savedStateHandle
+    if (savedState?.get<Boolean>("resume_line_editor") == true) {
+        showLineEditor = true
+        savedState.remove<Boolean>("resume_line_editor")
+    }
+
     PaperBackground(
         modifier = modifier
             .fillMaxSize()
@@ -105,6 +112,7 @@ fun LineParagraphPage(
 
     if (showLineEditor) {
         LineEditorPage(
+            navController = navController,
             initial = editingLine,
             onSave = { line ->
                 val index = lines.indexOfFirst { it.id == line.id }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/MovementEntryPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/MovementEntryPage.kt
@@ -66,9 +66,10 @@ val GaeguLight = FontFamily(Font(R.font.gaegu_light))
 fun MovementEntryPage(
     navController: NavController,
     editId: Long? = null,
+    initialName: String? = null,
     userCategories: List<String> = com.example.mygymapp.model.CustomCategories.list
 ) {
-    var name by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf(initialName ?: "") }
     var category by remember { mutableStateOf("") }
     var muscleGroup by remember { mutableStateOf("") }
     var rating by remember { mutableStateOf(0) }
@@ -439,6 +440,11 @@ fun MovementEntryPage(
                                 withContext(Dispatchers.IO) {
                                     if (editId != null) dao.update(exercise) else dao.insert(exercise)
                                 }
+                                // Signal the previous screen to reopen the line editor
+                                navController.previousBackStackEntry?.savedStateHandle?.set(
+                                    "resume_line_editor",
+                                    true
+                                )
                                 navController.popBackStack()
                             }
                         },


### PR DESCRIPTION
## Summary
- Add "Arms" before "Full Body" in muscle group chips
- Always provide keyed list in exercise modal for smoother filtering
- Trim and lowercase search text to avoid repeated allocations during scroll
- Show only "All" and "Full Body" until areas are selected in exercise sheet
- Recompute exercise filter options when selected areas change
- Offer quick creation of a new exercise when no search results match
- Persist Line Editor form fields and selections so returning from movement creation restores the previous state
- Reopen the Line Editor automatically after creating a new movement so users can continue editing seamlessly
- Draw vertical lines along the left edge of exercises to visually connect items in a superset
- Ensure superset lines span the full height of each exercise so adjacent cards connect cleanly

## Testing
- `./gradlew test` *(fails: SDK location not found; install Android SDK and accept licenses)*

------
https://chatgpt.com/codex/tasks/task_e_6894725c23c8832a9bb0fb54e3e9edc4