### PR TITLE
fix: remove stray shadow behind exercise cards

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.model.Exercise as LineExercise
@@ -37,7 +38,8 @@ fun ReorderableExerciseItem(
     onSupersetSelectedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     dragHandle: @Composable () -> Unit,
-    supersetPartnerIndices: List<Int> = emptyList()
+    supersetPartnerIndices: List<Int> = emptyList(),
+    elevation: Dp = 2.dp
 ) {
     val indices = (listOf(index) + supersetPartnerIndices).sorted()
     val isSuperset = supersetPartnerIndices.isNotEmpty()
@@ -82,7 +84,8 @@ fun ReorderableExerciseItem(
         PoeticCard(
             modifier = Modifier
                 .padding(vertical = 4.dp)
-                .weight(1f)
+                .weight(1f),
+            elevation = elevation
         ) {
             Column {
                     Row(

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import android.content.ClipData
@@ -402,8 +401,7 @@ fun LineEditorPage(
                                             }
                                         },
                                         modifier = Modifier
-                                            .animateItemPlacement()
-                                            .shadow(elevation),
+                                            .animateItemPlacement(),
                                         dragHandle = {
                                             Icon(
                                                 imageVector = Icons.Default.DragHandle,
@@ -414,7 +412,8 @@ fun LineEditorPage(
                                                 )
                                             )
                                         },
-                                        supersetPartnerIndices = partnerIndices
+                                        supersetPartnerIndices = partnerIndices,
+                                        elevation = elevation
                                     )
                                 }
                             }
@@ -499,7 +498,6 @@ fun LineEditorPage(
                                                 },
                                                 modifier = Modifier
                                                     .animateItemPlacement()
-                                                    .shadow(elevation)
                                                     .dragAndDropSource(
                                                         dataProvider = {
                                                             DragAndDropTransferData(
@@ -520,7 +518,8 @@ fun LineEditorPage(
                                                         )
                                                     )
                                                 },
-                                                supersetPartnerIndices = partnerIndices
+                                                supersetPartnerIndices = partnerIndices,
+                                                elevation = elevation
                                             )
                                         }
                                     }
@@ -610,7 +609,6 @@ fun LineEditorPage(
                                                     },
                                                     modifier = Modifier
                                                         .animateItemPlacement()
-                                                        .shadow(elevation)
                                                         .dragAndDropSource(
                                                             dataProvider = {
                                                                 DragAndDropTransferData(
@@ -631,7 +629,8 @@ fun LineEditorPage(
                                                             )
                                                         )
                                                     },
-                                                    supersetPartnerIndices = partnerIndices
+                                                    supersetPartnerIndices = partnerIndices,
+                                                    elevation = elevation
                                                 )
                                             }
                                         }


### PR DESCRIPTION
## Summary
- stop drawing extra rectangular shadow around LineEditorPage exercise cards
- forward card elevation to `PoeticCard` instead of outer modifier shadow

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a5d784b8832ab0e100f7fa19c2e4