### PR TITLE
fix: remove stray card shadow and draw bordered sections

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.model.Exercise as LineExercise
@@ -37,7 +38,8 @@ fun ReorderableExerciseItem(
     onSupersetSelectedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     dragHandle: @Composable () -> Unit,
-    supersetPartnerIndices: List<Int> = emptyList()
+    supersetPartnerIndices: List<Int> = emptyList(),
+    elevation: Dp = 2.dp
 ) {
     val indices = (listOf(index) + supersetPartnerIndices).sorted()
     val isSuperset = supersetPartnerIndices.isNotEmpty()
@@ -82,7 +84,8 @@ fun ReorderableExerciseItem(
         PoeticCard(
             modifier = Modifier
                 .padding(vertical = 4.dp)
-                .weight(1f)
+                .weight(1f),
+            elevation = elevation
         ) {
             Column {
                     Row(

--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
@@ -4,14 +4,20 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.ui.pages.GaeguBold
 
 /**
  * A poetic wrapper for grouping exercises into a section (e.g., Warm-up, Workout, Cooldown).
- * Wraps its content in a softly styled card with a header label.
+ * Instead of a full card, it draws a left and bottom line joined by a rounded corner,
+ * giving the impression that the section gently hugs its exercises.
  */
 @Composable
 fun SectionWrapper(
@@ -19,15 +25,47 @@ fun SectionWrapper(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    PoeticCard(modifier = modifier.padding(vertical = 12.dp)) {
-        Text(
-            text = title,
-            fontFamily = GaeguBold,
-            fontSize = 18.sp,
-            color = Color.Black,
-            modifier = Modifier.padding(bottom = 12.dp)
-        )
+    Box(
+        modifier = modifier
+            .padding(vertical = 12.dp)
+            .drawBehind {
+                val stroke = 2.dp.toPx()
+                val radius = 12.dp.toPx()
+                val w = size.width
+                val h = size.height
+                val path = Path().apply {
+                    moveTo(stroke / 2, 0f)
+                    lineTo(stroke / 2, h - radius - stroke / 2)
+                    arcTo(
+                        Rect(
+                            stroke / 2,
+                            h - 2 * radius - stroke / 2,
+                            stroke / 2 + 2 * radius,
+                            h - stroke / 2
+                        ),
+                        180f,
+                        -90f,
+                        false
+                    )
+                    lineTo(w - stroke / 2, h - stroke / 2)
+                }
+                drawPath(
+                    path = path,
+                    color = Color.Black,
+                    style = Stroke(width = stroke, cap = StrokeCap.Round)
+                )
+            }
+    ) {
+        Column(modifier = Modifier.padding(start = 12.dp, bottom = 12.dp)) {
+            Text(
+                text = title,
+                fontFamily = GaeguBold,
+                fontSize = 18.sp,
+                color = Color.Black,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
 
-        content()
+            content()
+        }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import android.content.ClipData
@@ -402,8 +401,7 @@ fun LineEditorPage(
                                             }
                                         },
                                         modifier = Modifier
-                                            .animateItemPlacement()
-                                            .shadow(elevation),
+                                            .animateItemPlacement(),
                                         dragHandle = {
                                             Icon(
                                                 imageVector = Icons.Default.DragHandle,
@@ -414,7 +412,8 @@ fun LineEditorPage(
                                                 )
                                             )
                                         },
-                                        supersetPartnerIndices = partnerIndices
+                                        supersetPartnerIndices = partnerIndices,
+                                        elevation = elevation
                                     )
                                 }
                             }
@@ -499,7 +498,6 @@ fun LineEditorPage(
                                                 },
                                                 modifier = Modifier
                                                     .animateItemPlacement()
-                                                    .shadow(elevation)
                                                     .dragAndDropSource(
                                                         dataProvider = {
                                                             DragAndDropTransferData(
@@ -520,7 +518,8 @@ fun LineEditorPage(
                                                         )
                                                     )
                                                 },
-                                                supersetPartnerIndices = partnerIndices
+                                                supersetPartnerIndices = partnerIndices,
+                                                elevation = elevation
                                             )
                                         }
                                     }
@@ -610,7 +609,6 @@ fun LineEditorPage(
                                                     },
                                                     modifier = Modifier
                                                         .animateItemPlacement()
-                                                        .shadow(elevation)
                                                         .dragAndDropSource(
                                                             dataProvider = {
                                                                 DragAndDropTransferData(
@@ -631,7 +629,8 @@ fun LineEditorPage(
                                                             )
                                                         )
                                                     },
-                                                    supersetPartnerIndices = partnerIndices
+                                                    supersetPartnerIndices = partnerIndices,
+                                                    elevation = elevation
                                                 )
                                             }
                                         }


### PR DESCRIPTION
## Summary
- stop drawing extra rectangular shadow around LineEditorPage exercise cards by forwarding elevation to `PoeticCard`
- show exercise sections with a left/bottom border joined by a rounded corner instead of a full card
- import `StrokeCap` from `androidx.compose.ui.graphics` to resolve build error
- align bottom section border so the right/bottom lines meet at a clean rounded corner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a5d784b8832ab0e100f7fa19c2e4