### PR TITLE
feat: drag exercises between sections and refine section borders

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.model.Exercise as LineExercise
@@ -37,7 +38,8 @@ fun ReorderableExerciseItem(
     onSupersetSelectedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     dragHandle: @Composable () -> Unit,
-    supersetPartnerIndices: List<Int> = emptyList()
+    supersetPartnerIndices: List<Int> = emptyList(),
+    elevation: Dp = 2.dp
 ) {
     val indices = (listOf(index) + supersetPartnerIndices).sorted()
     val isSuperset = supersetPartnerIndices.isNotEmpty()
@@ -82,7 +84,8 @@ fun ReorderableExerciseItem(
         PoeticCard(
             modifier = Modifier
                 .padding(vertical = 4.dp)
-                .weight(1f)
+                .weight(1f),
+            elevation = elevation
         ) {
             Column {
                     Row(

--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
@@ -4,14 +4,20 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.ui.pages.GaeguBold
 
 /**
  * A poetic wrapper for grouping exercises into a section (e.g., Warm-up, Workout, Cooldown).
- * Wraps its content in a softly styled card with a header label.
+ * Instead of a full card, it draws a left and bottom line joined by a rounded corner,
+ * giving the impression that the section gently hugs its exercises.
  */
 @Composable
 fun SectionWrapper(
@@ -19,15 +25,47 @@ fun SectionWrapper(
     modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    PoeticCard(modifier = modifier.padding(vertical = 12.dp)) {
-        Text(
-            text = title,
-            fontFamily = GaeguBold,
-            fontSize = 18.sp,
-            color = Color.Black,
-            modifier = Modifier.padding(bottom = 12.dp)
-        )
+    Box(
+        modifier = modifier
+            .padding(vertical = 12.dp)
+            .drawBehind {
+                val stroke = 2.dp.toPx()
+                val radius = 12.dp.toPx()
+                val w = size.width
+                val h = size.height
+                val path = Path().apply {
+                    moveTo(stroke / 2, 0f)
+                    lineTo(stroke / 2, h - radius - stroke / 2)
+                    arcTo(
+                        Rect(
+                            stroke / 2,
+                            h - 2 * radius - stroke / 2,
+                            stroke / 2 + 2 * radius,
+                            h - stroke / 2
+                        ),
+                        180f,
+                        -90f,
+                        false
+                    )
+                    lineTo(w - stroke / 2, h - stroke / 2)
+                }
+                drawPath(
+                    path = path,
+                    color = Color.Black,
+                    style = Stroke(width = stroke, cap = StrokeCap.Round)
+                )
+            }
+    ) {
+        Column(modifier = Modifier.padding(start = 12.dp, bottom = 12.dp)) {
+            Text(
+                text = title,
+                fontFamily = GaeguBold,
+                fontSize = 18.sp,
+                color = Color.Black,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
 
-        content()
+            content()
+        }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import android.content.ClipData
@@ -29,6 +28,7 @@ import com.example.mygymapp.ui.util.dragAndDropSource
 import com.example.mygymapp.ui.util.dragAndDropTarget
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.model.Line
@@ -125,6 +125,8 @@ fun LineEditorPage(
     }
 
     var showError by remember { mutableStateOf(false) }
+
+    var draggingSection by remember { mutableStateOf<String?>(null) }
 
     /**
      * Replace any groups containing the supplied ids and store the new grouping.
@@ -402,8 +404,7 @@ fun LineEditorPage(
                                             }
                                         },
                                         modifier = Modifier
-                                            .animateItemPlacement()
-                                            .shadow(elevation),
+                                            .animateItemPlacement(),
                                         dragHandle = {
                                             Icon(
                                                 imageVector = Icons.Default.DragHandle,
@@ -414,7 +415,8 @@ fun LineEditorPage(
                                                 )
                                             )
                                         },
-                                        supersetPartnerIndices = partnerIndices
+                                        supersetPartnerIndices = partnerIndices,
+                                        elevation = elevation
                                     )
                                 }
                             }
@@ -426,23 +428,27 @@ fun LineEditorPage(
                         if (unassignedItems.isNotEmpty()) {
                             SectionWrapper(
                                 title = "Unassigned",
-                                modifier = Modifier.dragAndDropTarget(
-                                    shouldStartDragAndDrop = { true },
-                                    onDrop = { transferData: DragAndDropTransferData ->
-                                        val id = transferData.clipData?.getItemAt(0)?.text?.toString()?.toLongOrNull()
-                                        id?.let { exId ->
-                                            val idx = selectedExercises.indexOfFirst { it.id == exId }
-                                            if (idx >= 0) {
-                                                val oldSection = selectedExercises[idx].section
-                                                selectedExercises[idx] = selectedExercises[idx].copy(section = "")
-                                                if (oldSection.isNotBlank() && selectedExercises.none { it.section == oldSection }) {
-                                                    sections.remove(oldSection)
+                                modifier = Modifier
+                                    .zIndex(if (draggingSection == "") 1f else 0f)
+                                    .dragAndDropTarget(
+                                        shouldStartDragAndDrop = { true },
+                                        onDrop = { transferData: DragAndDropTransferData ->
+                                            val id = transferData.clipData?.getItemAt(0)?.text?.toString()?.toLongOrNull()
+                                            id?.let { exId ->
+                                                val idx = selectedExercises.indexOfFirst { it.id == exId }
+                                                if (idx >= 0) {
+                                                    val item = selectedExercises.removeAt(idx)
+                                                    val oldSection = item.section
+                                                    val insertIdx = selectedExercises.indexOfLast { it.section.isBlank() } + 1
+                                                    selectedExercises.add(insertIdx, item.copy(section = ""))
+                                                    if (oldSection.isNotBlank() && selectedExercises.none { it.section == oldSection }) {
+                                                        sections.remove(oldSection)
+                                                    }
                                                 }
                                             }
+                                            true
                                         }
-                                        true
-                                    }
-                                )
+                                    )
                             ) {
                                 val reorderState = rememberReorderableLazyListState(
                                     onMove = { from, to ->
@@ -499,7 +505,6 @@ fun LineEditorPage(
                                                 },
                                                 modifier = Modifier
                                                     .animateItemPlacement()
-                                                    .shadow(elevation)
                                                     .dragAndDropSource(
                                                         dataProvider = {
                                                             DragAndDropTransferData(
@@ -508,7 +513,9 @@ fun LineEditorPage(
                                                                     item.id.toString()
                                                                 )
                                                             )
-                                                        }
+                                                        },
+                                                        onDragStart = { draggingSection = item.section },
+                                                        onDragEnd = { draggingSection = null }
                                                     ),
                                                 dragHandle = {
                                                     Icon(
@@ -520,7 +527,8 @@ fun LineEditorPage(
                                                         )
                                                     )
                                                 },
-                                                supersetPartnerIndices = partnerIndices
+                                                supersetPartnerIndices = partnerIndices,
+                                                elevation = elevation
                                             )
                                         }
                                     }
@@ -534,23 +542,27 @@ fun LineEditorPage(
                             if (sectionItems.isNotEmpty()) {
                                 SectionWrapper(
                                     title = sectionName,
-                                    modifier = Modifier.dragAndDropTarget(
-                                        shouldStartDragAndDrop = { true },
-                                        onDrop = { transferData: DragAndDropTransferData ->
-                                            val id = transferData.clipData?.getItemAt(0)?.text?.toString()?.toLongOrNull()
-                                            id?.let { exId ->
-                                                val idx = selectedExercises.indexOfFirst { it.id == exId }
-                                                if (idx >= 0) {
-                                                    val oldSection = selectedExercises[idx].section
-                                                    selectedExercises[idx] = selectedExercises[idx].copy(section = sectionName)
-                                                    if (oldSection.isNotBlank() && selectedExercises.none { it.section == oldSection }) {
-                                                        sections.remove(oldSection)
+                                    modifier = Modifier
+                                        .zIndex(if (draggingSection == sectionName) 1f else 0f)
+                                        .dragAndDropTarget(
+                                            shouldStartDragAndDrop = { true },
+                                            onDrop = { transferData: DragAndDropTransferData ->
+                                                val id = transferData.clipData?.getItemAt(0)?.text?.toString()?.toLongOrNull()
+                                                id?.let { exId ->
+                                                    val idx = selectedExercises.indexOfFirst { it.id == exId }
+                                                    if (idx >= 0) {
+                                                        val item = selectedExercises.removeAt(idx)
+                                                        val oldSection = item.section
+                                                        val insertIdx = selectedExercises.indexOfLast { it.section == sectionName } + 1
+                                                        selectedExercises.add(insertIdx, item.copy(section = sectionName))
+                                                        if (oldSection.isNotBlank() && oldSection != sectionName && selectedExercises.none { it.section == oldSection }) {
+                                                            sections.remove(oldSection)
+                                                        }
                                                     }
                                                 }
+                                                true
                                             }
-                                            true
-                                        }
-                                    )
+                                        )
                                 ) {
                                     val reorderState = rememberReorderableLazyListState(
                                         onMove = { from, to ->
@@ -610,7 +622,6 @@ fun LineEditorPage(
                                                     },
                                                     modifier = Modifier
                                                         .animateItemPlacement()
-                                                        .shadow(elevation)
                                                         .dragAndDropSource(
                                                             dataProvider = {
                                                                 DragAndDropTransferData(
@@ -619,7 +630,9 @@ fun LineEditorPage(
                                                                         item.id.toString()
                                                                     )
                                                                 )
-                                                            }
+                                                            },
+                                                            onDragStart = { draggingSection = item.section },
+                                                            onDragEnd = { draggingSection = null }
                                                         ),
                                                     dragHandle = {
                                                         Icon(
@@ -631,7 +644,8 @@ fun LineEditorPage(
                                                             )
                                                         )
                                                     },
-                                                    supersetPartnerIndices = partnerIndices
+                                                    supersetPartnerIndices = partnerIndices,
+                                                    elevation = elevation
                                                 )
                                             }
                                         }

--- a/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/util/DragAndDropCompat.kt
@@ -35,18 +35,22 @@ private object DragAndDropState {
  * pointer is released.
  */
 fun Modifier.dragAndDropSource(
-    dataProvider: () -> DragAndDropTransferData
+    dataProvider: () -> DragAndDropTransferData,
+    onDragStart: () -> Unit = {},
+    onDragEnd: () -> Unit = {}
 ): Modifier = pointerInput(Unit) {
     awaitEachGesture {
         val down = awaitFirstDown()
         val longPress = awaitLongPressOrCancellation(down.id)
         if (longPress != null) {
+            onDragStart()
             val session = DragSession(dataProvider())
             DragAndDropState.session = session
             waitForUpOrCancellation()
             if (DragAndDropState.session === session) {
                 DragAndDropState.session = null
             }
+            onDragEnd()
         }
     }
 }


### PR DESCRIPTION
## Summary
- let drag sources report start/end events so pages can react during a drag
- keep the source section above others while dragging so exercise cards stay visible
- stop drawing extra rectangular shadow around LineEditorPage exercise cards by forwarding elevation to `PoeticCard`
- show exercise sections with a left/bottom border joined by a rounded corner instead of a full card
- import `StrokeCap` from `androidx.compose.ui.graphics` to resolve build error
- align bottom section border so the right/bottom lines meet at a clean rounded corner
- allow dragging exercises between sections and append them to the target section on drop

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a5d784b8832ab0e100f7fa19c2e4