### PR TITLE
Track item bounds for accurate cross-section drag drop

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
@@ -27,6 +27,8 @@ fun SectionWrapper(
 ) {
     Box(
         modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 64.dp)
             .padding(vertical = 12.dp)
             .drawBehind {
                 val stroke = 2.dp.toPx()


### PR DESCRIPTION
## Summary
- track each exercise's vertical bounds and determine insert indices on drop
- convert drag coordinates to window space and record bounds from `onGloballyPositioned`
- widen `SectionWrapper` drop target with full width and minimum height

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c2890f98832a8701cd0bb313d050