### PR TITLE
Use Popup for drag preview in LineEditorPage

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -423,12 +422,8 @@ fun LineEditorPage(
                                 modifier = Modifier
                                     .heightIn(max = screenHeight)
                                     .graphicsLayer { clip = false }
-                                    .reorderable(reorderState)
-                                    .then(
-                                        if (!isDragging) {
-                                            Modifier.detectReorderAfterLongPress(reorderState)
-                                        } else Modifier
-                                    )
+                                    .then(if (!isDragging) Modifier.reorderable(reorderState) else Modifier)
+                                    .then(if (!isDragging) Modifier.detectReorderAfterLongPress(reorderState) else Modifier)
                                     .fillMaxWidth(),
                                 userScrollEnabled = false
                             ) {
@@ -560,12 +555,8 @@ fun LineEditorPage(
                                         modifier = Modifier
                                             .heightIn(max = screenHeight)
                                             .graphicsLayer { clip = false }
-                                            .reorderable(reorderState)
-                                            .then(
-                                                if (!isDragging) {
-                                                    Modifier.detectReorderAfterLongPress(reorderState)
-                                                } else Modifier
-                                            )
+                                            .then(if (!isDragging) Modifier.reorderable(reorderState) else Modifier)
+                                            .then(if (!isDragging) Modifier.detectReorderAfterLongPress(reorderState) else Modifier)
                                             .fillMaxWidth(),
                                         userScrollEnabled = false
                                     ) {
@@ -702,12 +693,8 @@ fun LineEditorPage(
                                             modifier = Modifier
                                                 .heightIn(max = screenHeight)
                                                 .graphicsLayer { clip = false }
-                                                .reorderable(reorderState)
-                                                .then(
-                                                    if (!isDragging) {
-                                                        Modifier.detectReorderAfterLongPress(reorderState)
-                                                    } else Modifier
-                                                )
+                                                .then(if (!isDragging) Modifier.reorderable(reorderState) else Modifier)
+                                                .then(if (!isDragging) Modifier.detectReorderAfterLongPress(reorderState) else Modifier)
                                                 .fillMaxWidth(),
                                             userScrollEnabled = false
                                         ) {
@@ -931,29 +918,22 @@ fun LineEditorPage(
                 val lineExercise = selectedExercises.find { it.id == id }
                 val previewName = dragPreview ?: lineExercise?.name ?: allExercises.find { it.id == id }?.name
                 previewName?.let { name ->
-                    val density = LocalDensity.current
-                    val offsetX = with(density) { dragPosition.x.toDp() }
-                    val offsetY = with(density) { dragPosition.y.toDp() }
-                    Box(
-                        Modifier
-                            .zIndex(999f)
-                            .absoluteOffset(
-                                x = offsetX,
-                                y = offsetY
-                            )
+                    androidx.compose.ui.window.Popup(
+                        alignment = Alignment.TopStart,
+                        offset = IntOffset(dragPosition.x.toInt(), dragPosition.y.toInt()),
+                        properties = androidx.compose.ui.window.PopupProperties(
+                            focusable = false,
+                            dismissOnBackPress = false,
+                            dismissOnClickOutside = false,
+                            clippingEnabled = false,
+                            usePlatformDefaultWidth = false
+                        )
                     ) {
                         PoeticCard {
-                            Column(
-                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-                            ) {
+                            Column(Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
                                 Text(name, fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
                                 lineExercise?.let {
-                                    Text(
-                                        "${it.sets} x ${it.repsOrDuration}",
-                                        fontFamily = GaeguRegular,
-                                        fontSize = 12.sp,
-                                        color = Color.Black
-                                    )
+                                    Text("${it.sets} x ${it.repsOrDuration}", fontFamily = GaeguRegular, fontSize = 12.sp, color = Color.Black)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Replace drag preview box with window Popup to use direct window coordinates
- Only enable reorder modifiers when no drag is active to avoid conflicts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896212538e4832aad9f500837b2127d