### PR TITLE
Animate drop zones and highlight supersets in line editor

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -1,8 +1,11 @@
 package com.example.mygymapp.ui.components
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Checkbox
@@ -11,6 +14,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,6 +38,7 @@ fun ReorderableExerciseItem(
     modifier: Modifier = Modifier,
     dragHandle: @Composable () -> Unit,
     supersetPartnerIndices: List<Int> = emptyList(),
+    isDraggingPartner: Boolean = false,
     elevation: Dp = 2.dp
 ) {
     val indices = (listOf(index) + supersetPartnerIndices).sorted()
@@ -62,14 +67,33 @@ fun ReorderableExerciseItem(
             Spacer(Modifier.width(16.dp))
         }
 
-        PoeticCard(
+        val highlightColor by animateColorAsState(
+            targetValue = when {
+                isDraggingPartner -> Color(0xFFFFF59D)
+                isSuperset -> Color(0xFFFFFDE7)
+                else -> Color.Transparent
+            }
+        )
+        val borderColor by animateColorAsState(
+            targetValue = when {
+                isDraggingPartner -> Color(0xFFFBC02D)
+                isSuperset -> Color(0xFFFFF59D)
+                else -> Color.Transparent
+            }
+        )
+        Box(
             modifier = Modifier
                 .padding(vertical = 4.dp)
                 .weight(1f)
-                .graphicsLayer(clip = false),   // <- HIER rein, noch vor der schließenden Klammer
-            elevation = elevation
+                .graphicsLayer(clip = false)
+                .background(highlightColor)
+                .border(1.dp, borderColor)
         ) {
-            Column {
+            PoeticCard(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = elevation
+            ) {
+                Column {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -30,11 +32,13 @@ fun SectionWrapper(
     isDropActive: Boolean = false,            // NEW
     content: @Composable ColumnScope.() -> Unit
 ) {
+    val paddingY by animateDpAsState(targetValue = if (isDropActive) 20.dp else 12.dp)
     Box(
-        modifier = modifier
+        modifier = Modifier
+            .padding(vertical = paddingY)
+            .then(modifier)
             .fillMaxWidth()
             .defaultMinSize(minHeight = minDropHeightDp.dp)
-            .padding(vertical = 12.dp)
             .drawBehind {
                 val stroke = 2.dp.toPx()
                 val radius = 12.dp.toPx()

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
@@ -2,6 +2,7 @@ package com.example.mygymapp.ui.pages
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -409,6 +410,7 @@ fun SectionsWithDragDrop(
             val isDropActive = dragState.hoveredSection == ""
             val bgColor by animateColorAsState(if (isDropActive) Color(0xFFF5F5DC) else Color.Transparent)
             val borderColor by animateColorAsState(if (isDropActive) Color(0xFFE0DCC8) else Color.Transparent)
+            val extraPadding by animateDpAsState(if (isDropActive) 8.dp else 0.dp)
             Box(
                 modifier = Modifier
                     .onGloballyPositioned {
@@ -419,6 +421,7 @@ fun SectionsWithDragDrop(
                     .background(bgColor)
                     .border(1.dp, borderColor)
                     .shadow(if (isDropActive) 4.dp else 0.dp)
+                    .padding(vertical = extraPadding)
                     .fillMaxWidth()
             ) {
                 LazyColumn(
@@ -436,6 +439,7 @@ fun SectionsWithDragDrop(
                             val partnerIndices = supersetHelper.partners(item.id).mapNotNull { pid ->
                                 selectedExercises.indexOfFirst { it.id == pid }.takeIf { it >= 0 }
                             }
+                            val isDraggingPartner = dragState.draggingExerciseId?.let { supersetHelper.partners(it).contains(item.id) } == true
                             var itemOffset by remember { mutableStateOf(Offset.Zero) }
                             ReorderableExerciseItem(
                                 index = index,
@@ -461,7 +465,7 @@ fun SectionsWithDragDrop(
                                         itemOffset = topLeft
                                         val size = it.size.toSize()
                                         dragState.itemBounds[item.id] = topLeft.y to (topLeft.y + size.height)
-                                    },
+                                },
                                 dragHandle = {
                                     var handleOffset by remember { mutableStateOf(Offset.Zero) }
                                     Icon(
@@ -474,6 +478,7 @@ fun SectionsWithDragDrop(
                                     )
                                 },
                                 supersetPartnerIndices = partnerIndices,
+                                isDraggingPartner = isDraggingPartner,
                                 elevation = elevation
                             )
                         }
@@ -522,6 +527,7 @@ fun SectionsWithDragDrop(
                                 val partnerIndices = supersetHelper.partners(item.id).mapNotNull { pid ->
                                     selectedExercises.indexOfFirst { it.id == pid }.takeIf { it >= 0 }
                                 }
+                                val isDraggingPartner = dragState.draggingExerciseId?.let { supersetHelper.partners(it).contains(item.id) } == true
                                 var itemOffset by remember { mutableStateOf(Offset.Zero) }
                                 ReorderableExerciseItem(
                                     index = index,
@@ -547,7 +553,7 @@ fun SectionsWithDragDrop(
                                             itemOffset = topLeft
                                             val size = it.size.toSize()
                                             dragState.itemBounds[item.id] = topLeft.y to (topLeft.y + size.height)
-                                        },
+                                    },
                                     dragHandle = {
                                         var handleOffset by remember { mutableStateOf(Offset.Zero) }
                                         Icon(
@@ -560,6 +566,7 @@ fun SectionsWithDragDrop(
                                         )
                                     },
                                     supersetPartnerIndices = partnerIndices,
+                                    isDraggingPartner = isDraggingPartner,
                                     elevation = elevation
                                 )
                             }
@@ -605,6 +612,7 @@ fun SectionsWithDragDrop(
                                 val partnerIndices = supersetHelper.partners(item.id).mapNotNull { pid ->
                                     selectedExercises.indexOfFirst { it.id == pid }.takeIf { it >= 0 }
                                 }
+                                val isDraggingPartner = dragState.draggingExerciseId?.let { supersetHelper.partners(it).contains(item.id) } == true
                                 var itemOffset by remember { mutableStateOf(Offset.Zero) }
                                 ReorderableExerciseItem(
                                     index = index,
@@ -644,6 +652,7 @@ fun SectionsWithDragDrop(
                                         )
                                     },
                                     supersetPartnerIndices = partnerIndices,
+                                    isDraggingPartner = isDraggingPartner,
                                     elevation = elevation
                                 )
                             }


### PR DESCRIPTION
## Summary
- Animate drop-zone padding for section containers to expand when hovered
- Highlight exercises that belong to supersets and emphasize partners while dragging

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971f600b10832a85cff9f2527c5cc6