### PR TITLE
Refine line editor interactions

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LinedTextField.kt
@@ -2,8 +2,10 @@ package com.example.mygymapp.ui.components
 
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -26,7 +28,8 @@ fun LinedTextField(
     modifier: Modifier = Modifier,
     lineHeight: Dp = 32.dp,
     initialLines: Int = 3,
-    padding: Dp = 12.dp
+    padding: Dp = 12.dp,
+    isError: Boolean = false
 ) {
     val density = LocalDensity.current
     val textStyle = TextStyle(
@@ -43,11 +46,14 @@ fun LinedTextField(
     val totalLineCount = maxOf(layoutLineCount, initialLines)
     val fieldHeight = lineHeight * totalLineCount
 
+    val borderColor by animateColorAsState(if (isError) Color.Red else Color.Transparent)
+
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(fieldHeight)
             .padding(horizontal = padding)
+            .border(2.dp, borderColor)
     ) {
         // 🎯 Linien zeichnen – mit absolutem Schutz gegen Absturz
         Canvas(modifier = Modifier.matchParentSize()) {

--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material3.Checkbox
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -139,10 +141,19 @@ fun ReorderableExerciseItem(
                                     color = Color.Black
                                 )
                             }
-                            Checkbox(
+                            IconToggleButton(
                                 checked = isSupersetSelected,
                                 onCheckedChange = onSupersetSelectedChange
-                            )
+                            ) {
+                                val tint by animateColorAsState(
+                                    if (isSupersetSelected) Color(0xFF2E7D32) else Color.Gray
+                                )
+                                Icon(
+                                    imageVector = if (isSupersetSelected) Icons.Filled.Link else Icons.Outlined.Link,
+                                    contentDescription = "Superset",
+                                    tint = tint
+                                )
+                            }
                             dragHandle()
                         }
                     }

--- a/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/SectionWrapper.kt
@@ -9,6 +9,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateDp
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.RepeatMode
 import androidx.compose.runtime.getValue
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,6 +38,12 @@ fun SectionWrapper(
     content: @Composable ColumnScope.() -> Unit
 ) {
     val paddingY by animateDpAsState(targetValue = if (isDropActive) 20.dp else 12.dp)
+    val infinite = rememberInfiniteTransition()
+    val animatedStroke by infinite.animateDp(
+        initialValue = 2.dp,
+        targetValue = 4.dp,
+        animationSpec = infiniteRepeatable(tween(600), RepeatMode.Reverse)
+    )
     Box(
         modifier = Modifier
             .padding(vertical = paddingY)
@@ -40,7 +51,7 @@ fun SectionWrapper(
             .fillMaxWidth()
             .defaultMinSize(minHeight = minDropHeightDp.dp)
             .drawBehind {
-                val stroke = 2.dp.toPx()
+                val stroke = if (isDropActive) animatedStroke.toPx() else 2.dp.toPx()
                 val radius = 12.dp.toPx()
                 val w = size.width
                 val h = size.height

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.border
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
@@ -17,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -103,6 +108,16 @@ fun LineEditorPage(
     val snackbarHostState = remember { SnackbarHostState() }
     val dragState = remember { DragAndDropState() }
 
+    LaunchedEffect(showError) {
+        if (showError) {
+            if (title.isBlank()) {
+                scrollState.animateScrollTo(0)
+            } else if (selectedExercises.isEmpty()) {
+                exerciseBringIntoView.bringIntoView()
+            }
+        }
+    }
+
     fun findInsertIndexForDrop(sectionName: String, dropY: Float): Int {
         val entries = selectedExercises.withIndex().filter { it.value.section == sectionName }
         if (entries.isEmpty()) {
@@ -123,6 +138,9 @@ fun LineEditorPage(
         Modifier.exerciseDrag(dragState, id, name, section, offset, allExercises, selectedExercises, sections, ::findInsertIndexForDrop, start)
     }
 
+    val scrollState = rememberScrollState()
+    val exerciseBringIntoView = remember { BringIntoViewRequester() }
+
     Scaffold(
         snackbarHost = {
             SnackbarHost(snackbarHostState) { data ->
@@ -140,7 +158,7 @@ fun LineEditorPage(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
+                        .verticalScroll(scrollState)
                         .systemBarsPadding()
                         .padding(24.dp),
                     verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -148,6 +166,7 @@ fun LineEditorPage(
                 ) {
                     Text("✔ Compose your daily line", fontFamily = GaeguBold, fontSize = 24.sp, color = Color.Black)
 
+                    val titleError = showError && title.isBlank()
                     LineTitleAndCategoriesSection(
                         title = title,
                         onTitleChange = { title = it },
@@ -156,7 +175,8 @@ fun LineEditorPage(
                         onCategoryChange = { selectedCategories.clear(); selectedCategories.addAll(it) },
                         muscleOptions = muscleOptions,
                         selectedMuscles = selectedMuscles,
-                        onMuscleChange = { selectedMuscles.clear(); selectedMuscles.addAll(it) }
+                        onMuscleChange = { selectedMuscles.clear(); selectedMuscles.addAll(it) },
+                        titleError = titleError
                     )
 
                     LineNotesSection(note = note, onNoteChange = { note = it })
@@ -183,31 +203,24 @@ fun LineEditorPage(
                         onDismiss = { showExerciseSheet.value = false }
                     )
 
-                    SectionsWithDragDrop(
-                        sections = sections,
-                        selectedExercises = selectedExercises,
-                        supersetHelper = supersetHelper,
-                        supersetSelection = supersetSelection,
-                        dragState = dragState,
-                        allExercises = allExercises,
-                        dragModifier = dragModifier,
-                        findInsertIndexForDrop = ::findInsertIndexForDrop
+                    val exerciseBorderColor by animateColorAsState(
+                        if (showError && selectedExercises.isEmpty()) Color.Red else Color.Transparent
                     )
-
-                    if (showError) {
-                        Box(
-                            Modifier
-                                .fillMaxWidth()
-                                .background(Color(0xFFF5F5F0))
-                                .padding(8.dp)
-                        ) {
-                            Text(
-                                "Please fill out title and at least one exercise",
-                                color = Color.DarkGray,
-                                fontFamily = FontFamily.Serif,
-                                fontSize = 14.sp
-                            )
-                        }
+                    Box(
+                        Modifier
+                            .border(2.dp, exerciseBorderColor)
+                            .bringIntoViewRequester(exerciseBringIntoView)
+                    ) {
+                        SectionsWithDragDrop(
+                            sections = sections,
+                            selectedExercises = selectedExercises,
+                            supersetHelper = supersetHelper,
+                            supersetSelection = supersetSelection,
+                            dragState = dragState,
+                            allExercises = allExercises,
+                            dragModifier = dragModifier,
+                            findInsertIndexForDrop = ::findInsertIndexForDrop
+                        )
                     }
 
                     PoeticDivider()
@@ -242,6 +255,23 @@ fun LineEditorPage(
                 }
             }
 
+            if (showError) {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color(0xAA000000)),
+                    contentAlignment = Alignment.TopCenter
+                ) {
+                    PoeticCard(modifier = Modifier.padding(top = 48.dp)) {
+                        Text(
+                            "Diese Seite ist noch unvollständig.",
+                            fontFamily = GaeguRegular,
+                            color = Color.Black
+                        )
+                    }
+                }
+            }
+
             if (dragState.isDragging && dragState.draggingExerciseId != null) {
                 val id = dragState.draggingExerciseId!!
                 val lineExercise = selectedExercises.find { it.id == id }
@@ -250,9 +280,10 @@ fun LineEditorPage(
                     Box(
                         Modifier
                             .absoluteOffset(x = dragState.dragPosition.x.dp, y = dragState.dragPosition.y.dp)
-                            .shadow(6.dp)
+                            .shadow(8.dp)
+                            .alpha(0.7f)
                     ) {
-                        PoeticCard {
+                        PoeticCard(tintOverlayAlpha = 0.3f) {
                             Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
                                 Text(name, fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
                                 lineExercise?.let {


### PR DESCRIPTION
## Summary
- Highlight required fields with animated red borders and scroll to the first invalid section
- Replace superset checkboxes with link-style toggle icons and soften drag/drop visuals
- Pulse drop-zone borders and lighten drag previews for a paper-like feel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689723d952f0832a879af2ac1fff5654