### PR TITLE
Derive sections from selected exercises

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -66,14 +66,12 @@ fun LineEditorPage(
     ) {
         mutableStateListOf<LineExercise>().apply { initial?.exercises?.let { addAll(it) } }
     }
-    val sections = rememberSaveable(
-        saver = listSaver<SnapshotStateList<String>, String>(
-            save = { ArrayList(it) },
-            restore = { it.toMutableStateList() }
-        )
-    ) {
-        mutableStateListOf<String>().apply {
-            initial?.exercises?.map { it.section }?.filter { it.isNotBlank() }?.distinct()?.let { addAll(it) }
+    val sections by remember {
+        derivedStateOf {
+            selectedExercises
+                .map { it.section }
+                .filter { it.isNotBlank() }
+                .distinct()
         }
     }
     val supersets = rememberSaveable(
@@ -145,7 +143,6 @@ fun LineEditorPage(
             offset,
             allExercises,
             selectedExercises,
-            sections,
             ::findInsertIndexForDrop,
             supersetHelper,
             start


### PR DESCRIPTION
## Summary
- derive sections from `selectedExercises` using `derivedStateOf`
- simplify drag-and-drop and section move logic to rely solely on `selectedExercises`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689739907898832a8d8afddb59621397