### PR TITLE
Derive sections from selected exercises

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/WaxSealButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/WaxSealButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.ui.draw.alpha
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,13 +41,15 @@ fun WaxSealButton(
     textSize: TextUnit = 16.sp,
     shadowColor: Color = Color.Black,
     shadowOffset: Offset = Offset(1f, 1f),
-    sealSize: Dp = 100.dp
+    sealSize: Dp = 100.dp,
+    enabled: Boolean = true
 ) {
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(sealSize)
-            .clickable { onClick() },
+            .alpha(if (enabled) 1f else 0.5f)
+            .clickable(enabled = enabled) { onClick() },
         contentAlignment = Alignment.Center
     ) {
         Image(


### PR DESCRIPTION
## Summary
- derive sections from `selectedExercises` using `derivedStateOf`
- rely on burnoutcrew for intra-section moves and handle cross-section drops with a lightweight drag state
- encapsulate superset operations in `SupersetState` so the UI only queries partners or group flags
- disable Create until a title and at least one movement are provided, scrolling to the missing field and showing a snackbar on invalid attempts

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689739907898832a8d8afddb59621397