### PR TITLE
Fix filtering, strings, drag preview, and superset toggles

### DIFF
--- a/app/src/main/java/com/example/mygymapp/data/ExerciseGoalStore.kt
+++ b/app/src/main/java/com/example/mygymapp/data/ExerciseGoalStore.kt
@@ -7,10 +7,10 @@ class ExerciseGoalStore private constructor(context: Context) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences("exercise_goals", Context.MODE_PRIVATE)
 
-    fun getGoal(exerciseId: Long): Int = prefs.getInt("goal_${'$'}exerciseId", 0)
+    fun getGoal(exerciseId: Long): Int = prefs.getInt("goal_${exerciseId}", 0)
 
     fun setGoal(exerciseId: Long, target: Int) {
-        prefs.edit().putInt("goal_${'$'}exerciseId", target).apply()
+        prefs.edit().putInt("goal_${exerciseId}", target).apply()
     }
 
     companion object {

--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseCard.kt
@@ -44,7 +44,7 @@ fun ExerciseCard(
             Column(Modifier.weight(1f)) {
                 Text(ex.name, style = MaterialTheme.typography.titleMedium)
                 Text(
-                    "${'$'}{ex.muscleGroup.display} • ${'$'}{ex.customCategory ?: ex.category.name}",
+                    "${ex.muscleGroup.display} • ${ex.customCategory ?: ex.category.name}",
                     style = MaterialTheme.typography.bodySmall
                 )
             }

--- a/app/src/main/java/com/example/mygymapp/ui/components/ExerciseHighlightCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ExerciseHighlightCard.kt
@@ -57,7 +57,7 @@ fun ExerciseCardWithHighlight(
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
-                    text = "${'$'}{ex.muscleGroup.display} · ${'$'}{ex.customCategory ?: ex.category.name}",
+                    text = "${ex.muscleGroup.display} · ${ex.customCategory ?: ex.category.name}",
                     style = MaterialTheme.typography.bodyMedium.copy(fontFamily = GaeguRegular),
                     color = Color.DarkGray
                 )

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticLineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticLineCard.kt
@@ -39,7 +39,7 @@ fun PoeticLineCard(
         )
         Spacer(Modifier.height(4.dp))
         Text(
-            text = "${'$'}{line.category} · ${'$'}{line.muscleGroup}",
+            text = "${line.category} · ${line.muscleGroup}",
             style = MaterialTheme.typography.bodySmall.copy(
                 fontFamily = GaeguLight,
                 color = Color(0xFF5D4037)

--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -8,6 +8,8 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.TextButton
@@ -39,6 +41,8 @@ fun ReorderableExerciseItem(
     supersetPartnerIndices: List<Int> = emptyList(),
     isDraggingPartner: Boolean = false,
     isDragTarget: Boolean = false,
+    isLinkedWithNext: Boolean = false,
+    onToggleSuperset: (() -> Unit)? = null,
     elevation: Dp = 2.dp
 ) {
     val indices = (listOf(index) + supersetPartnerIndices).sorted()
@@ -139,6 +143,16 @@ fun ReorderableExerciseItem(
                                     fontFamily = GaeguRegular,
                                     fontSize = 14.sp,
                                     color = Color.Black
+                                )
+                            }
+                            IconButton(
+                                onClick = { onToggleSuperset?.invoke() },
+                                enabled = onToggleSuperset != null
+                            ) {
+                                Icon(
+                                    imageVector = if (isLinkedWithNext) Icons.Filled.Link else Icons.Filled.LinkOff,
+                                    contentDescription = "Toggle superset with next",
+                                    tint = if (isLinkedWithNext) Color(0xFF2E7D32) else Color.Gray
                                 )
                             }
                             dragHandle()

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.keyframes
@@ -101,6 +102,7 @@ fun LineEditorPage(
             offset,
             allExercises,
             selectedExercises,
+            supersetState,
             ::findInsertIndexForDrop,
             start
         )
@@ -260,13 +262,17 @@ fun LineEditorPage(
             }
 
             if (dragState.isDragging && dragState.draggingExerciseId != null) {
+                val density = LocalDensity.current
                 val id = dragState.draggingExerciseId!!
                 val lineExercise = selectedExercises.find { it.id == id }
                 val previewName = dragState.dragPreview ?: lineExercise?.name ?: allExercises.find { it.id == id }?.name
                 previewName?.let { name ->
                     Box(
                         Modifier
-                            .absoluteOffset(x = dragState.dragPosition.x.dp, y = dragState.dragPosition.y.dp)
+                            .absoluteOffset(
+                                x = with(density) { dragState.dragPosition.x.toDp() },
+                                y = with(density) { dragState.dragPosition.y.toDp() }
+                            )
                             .shadow(8.dp)
                             .alpha(0.85f)
                             .graphicsLayer { rotationZ = -3f }


### PR DESCRIPTION
## Summary
- normalize exercise category filtering and support custom categories
- repair string interpolation and clean up special characters
- convert drag preview offsets with density and add superset link toggles

## Testing
- `./gradlew -q assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689787b29c70832aa3a569864751af7c