### PR TITLE
Allow saving paragraphs without full week selection

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphEditorPageSwipe.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -66,8 +67,6 @@ fun ParagraphEditorPageSwipe(
     val pagerState = rememberPagerState(pageCount = { 7 })
     val coroutineScope = rememberCoroutineScope()
     var showSavedOverlay by remember { mutableStateOf(false) }
-    val snackbarHostState = remember { SnackbarHostState() }
-
     PaperBackground(
         modifier = Modifier
             .fillMaxSize()
@@ -75,7 +74,6 @@ fun ParagraphEditorPageSwipe(
             .imePadding(),
     ) {
         Scaffold(
-            snackbarHost = { SnackbarHost(snackbarHostState) },
             containerColor = Color.Transparent
         ) { innerPadding ->
             Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
@@ -360,25 +358,21 @@ fun ParagraphEditorPageSwipe(
                     Spacer(Modifier.height(16.dp))
                 }
 
+                val context = LocalContext.current
                 Button(
                     onClick = {
-                        if (selectedLines.any { it == null }) {
-                            coroutineScope.launch {
-                                snackbarHostState.showSnackbar("Select a line for each day")
-                            }
-                        } else {
-                            val lineTitles = selectedLines.map { it?.title ?: "" }
-                            val paragraph = Paragraph(
-                                id = initial?.id ?: System.currentTimeMillis(),
-                                title = title,
-                                lineTitles = lineTitles,
-                                note = note,
-                            )
-                            showSavedOverlay = true
-                            coroutineScope.launch {
-                                delay(1000)
-                                onSave(paragraph)
-                            }
+                        val restDay = context.getString(R.string.rest_day)
+                        val lineTitles = selectedLines.map { it?.title ?: restDay }
+                        val paragraph = Paragraph(
+                            id = initial?.id ?: System.currentTimeMillis(),
+                            title = title,
+                            lineTitles = lineTitles,
+                            note = note,
+                        )
+                        showSavedOverlay = true
+                        coroutineScope.launch {
+                            delay(1000)
+                            onSave(paragraph)
                         }
                     },
                     modifier = Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,4 +153,5 @@
     <string name="drop_zone_hovered">current drop target</string>
     <string name="sets_reps_format">%1$d x %2$s</string>
     <string name="unassigned">Unassigned</string>
+    <string name="rest_day">Rest Day</string>
 </resources>


### PR DESCRIPTION
## Summary
- Let Paragraph Editor save even when some days are unassigned
- Default missing days to a "Rest Day" label via string resources
- Remove unused snackbar logic from editor

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68978de962b0832aa788bf71a3462372