### PR TITLE
Enable swipe-to-delete in line editor

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -6,10 +6,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,8 +28,7 @@ import androidx.compose.ui.draw.rotate
 @Composable
 fun ReorderableExerciseItem(
     index: Int,
-    exercise: com.example.mygymapp.model.Exercise,
-    onRemove: () -> Unit,
+    exercise: LineExercise,
     onMove: () -> Unit,
     modifier: Modifier = Modifier,
     dragHandle: @Composable () -> Unit,
@@ -125,13 +122,6 @@ fun ReorderableExerciseItem(
                         }
                         // Actions
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            IconButton(onClick = onRemove) {
-                                Icon(
-                                    imageVector = Icons.Default.Delete,
-                                    contentDescription = "Delete",
-                                    tint = Color.Red
-                                )
-                            }
                             TextButton(onClick = onMove) {
                                 Text(
                                     "Move",

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
@@ -17,6 +17,12 @@ import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.DismissDirection
+import androidx.compose.material.DismissValue
+import androidx.compose.material.SwipeToDismiss
+import androidx.compose.material.rememberDismissState
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -375,7 +381,7 @@ fun ExercisePickerSheet(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun SectionsWithDragDrop(
     sections: List<String>,
@@ -657,47 +663,75 @@ fun SectionsWithDragDrop(
                                             )
                                         )
                                     }
-                                    ReorderableExerciseItem(
-                                        index = index,
-                                        exercise = item,
-                                        onRemove = { removeExercise(item) },
-                                        onMove = {
-                                            showMoveSheet = true
-                                            moveSelection.clear(); moveSelection.add(item.id)
-                                            moveSelectedOption = null; moveCustomName = ""
+                                    val dismissState = rememberDismissState(confirmStateChange = { value ->
+                                        if (value == DismissValue.DismissedToStart) {
+                                            removeExercise(item)
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    })
+                                    SwipeToDismiss(
+                                        state = dismissState,
+                                        directions = if (dragState.isDragging) emptySet() else setOf(DismissDirection.EndToStart),
+                                        background = {
+                                            Box(
+                                                Modifier
+                                                    .fillMaxSize()
+                                                    .background(Color.Red)
+                                                    .padding(horizontal = 20.dp),
+                                                contentAlignment = Alignment.CenterEnd
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Delete,
+                                                    contentDescription = null,
+                                                    tint = Color.White
+                                                )
+                                            }
                                         },
-                                        modifier = Modifier
-                                            .alpha(if (dragState.draggingExerciseId == item.id) 0f else 1f)
-                                            .onGloballyPositioned {
-                                                val topLeft = it.positionInWindow()
-                                                val size = it.size.toSize()
-                                                dragState.itemBounds[item.id] =
-                                                    topLeft.y to (topLeft.y + size.height)
-                                            },
-                                        dragHandle = {
-                                            var handleOffset by remember { mutableStateOf(Offset.Zero) }
-                                            Icon(
-                                                imageVector = Icons.Default.DragHandle,
-                                                contentDescription = stringResource(R.string.reorder_movement),
-                                                tint = Color.Gray,
+                                        dismissContent = {
+                                            ReorderableExerciseItem(
+                                                index = index,
+                                                exercise = item,
+                                                onMove = {
+                                                    showMoveSheet = true
+                                                    moveSelection.clear(); moveSelection.add(item.id)
+                                                    moveSelectedOption = null; moveCustomName = ""
+                                                },
                                                 modifier = Modifier
+                                                    .alpha(if (dragState.draggingExerciseId == item.id) 0f else 1f)
                                                     .onGloballyPositioned {
-                                                        if (!dragState.isDragging) {
-                                                            handleOffset = it.positionInWindow()
-                                                        }
-                                                    }
-                                                    .then(
-                                                        dragModifier(
-                                                            item.id,
-                                                            item.name,
-                                                            item.section,
-                                                            { handleOffset }) { })
+                                                        val topLeft = it.positionInWindow()
+                                                        val size = it.size.toSize()
+                                                        dragState.itemBounds[item.id] =
+                                                            topLeft.y to (topLeft.y + size.height)
+                                                    },
+                                                dragHandle = {
+                                                    var handleOffset by remember { mutableStateOf(Offset.Zero) }
+                                                    Icon(
+                                                        imageVector = Icons.Default.DragHandle,
+                                                        contentDescription = stringResource(R.string.reorder_movement),
+                                                        tint = Color.Gray,
+                                                        modifier = Modifier
+                                                            .onGloballyPositioned {
+                                                                if (!dragState.isDragging) {
+                                                                    handleOffset = it.positionInWindow()
+                                                                }
+                                                            }
+                                                            .then(
+                                                                dragModifier(
+                                                                    item.id,
+                                                                    item.name,
+                                                                    item.section,
+                                                                    { handleOffset }) { })
+                                                    )
+                                                },
+                                                supersetPartnerIndices = partnerIndices,
+                                                isDraggingPartner = isDraggingPartner,
+                                                isDragTarget = isInRange,
+                                                elevation = elevation
                                             )
-                                        },
-                                        supersetPartnerIndices = partnerIndices,
-                                        isDraggingPartner = isDraggingPartner,
-                                        isDragTarget = isInRange,
-                                        elevation = elevation
+                                        }
                                     )
                                 }
                             }
@@ -776,47 +810,76 @@ fun SectionsWithDragDrop(
                                                 )
                                             )
                                         }
-                                        ReorderableExerciseItem(
-                                            index = index,
-                                            exercise = item,
-                                            onRemove = { removeExercise(item) },
-                                            onMove = {
-                                                showMoveSheet = true
-                                                moveSelection.clear(); moveSelection.add(item.id)
-                                                moveSelectedOption = null; moveCustomName = ""
+                                        val dismissState = rememberDismissState(confirmStateChange = { value ->
+                                            if (value == DismissValue.DismissedToStart) {
+                                                removeExercise(item)
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        })
+                                        SwipeToDismiss(
+                                            state = dismissState,
+                                            directions = if (dragState.isDragging) emptySet() else setOf(DismissDirection.EndToStart),
+                                            background = {
+                                                Box(
+                                                    Modifier
+                                                        .fillMaxSize()
+                                                        .background(Color.Red)
+                                                        .padding(horizontal = 20.dp),
+                                                    contentAlignment = Alignment.CenterEnd
+                                                ) {
+                                                    Icon(
+                                                        imageVector = Icons.Default.Delete,
+                                                        contentDescription = null,
+                                                        tint = Color.White
+                                                    )
+                                                }
                                             },
-                                            modifier = Modifier
-                                                .alpha(if (dragState.draggingExerciseId == item.id) 0f else 1f)
-                                                .onGloballyPositioned {
-                                                    val topLeft = it.positionInWindow()
-                                                    val size = it.size.toSize()
-                                                    dragState.itemBounds[item.id] =
-                                                        topLeft.y to (topLeft.y + size.height)
-                                                },
-                                            dragHandle = {
-                                                var handleOffset by remember { mutableStateOf(Offset.Zero) }
-                                                Icon(
-                                                    imageVector = Icons.Default.DragHandle,
-                                                    contentDescription = stringResource(R.string.reorder_movement),
-                                                    tint = Color.Gray,
+                        
+                                            dismissContent = {
+                                                ReorderableExerciseItem(
+                                                    index = index,
+                                                    exercise = item,
+                                                    onMove = {
+                                                        showMoveSheet = true
+                                                        moveSelection.clear(); moveSelection.add(item.id)
+                                                        moveSelectedOption = null; moveCustomName = ""
+                                                    },
                                                     modifier = Modifier
+                                                        .alpha(if (dragState.draggingExerciseId == item.id) 0f else 1f)
                                                         .onGloballyPositioned {
-                                                            if (!dragState.isDragging) {
-                                                                handleOffset = it.positionInWindow()
-                                                            }
-                                                        }
-                                                        .then(
-                                                            dragModifier(
-                                                                item.id,
-                                                                item.name,
-                                                                item.section,
-                                                                { handleOffset }) { })
+                                                            val topLeft = it.positionInWindow()
+                                                            val size = it.size.toSize()
+                                                            dragState.itemBounds[item.id] =
+                                                                topLeft.y to (topLeft.y + size.height)
+                                                        },
+                                                    dragHandle = {
+                                                        var handleOffset by remember { mutableStateOf(Offset.Zero) }
+                                                        Icon(
+                                                            imageVector = Icons.Default.DragHandle,
+                                                            contentDescription = stringResource(R.string.reorder_movement),
+                                                            tint = Color.Gray,
+                                                            modifier = Modifier
+                                                                .onGloballyPositioned {
+                                                                    if (!dragState.isDragging) {
+                                                                        handleOffset = it.positionInWindow()
+                                                                    }
+                                                                }
+                                                                .then(
+                                                                    dragModifier(
+                                                                        item.id,
+                                                                        item.name,
+                                                                        item.section,
+                                                                        { handleOffset }) { })
+                                                        )
+                                                    },
+                                                    supersetPartnerIndices = partnerIndices,
+                                                    isDraggingPartner = isDraggingPartner,
+                                                    isDragTarget = isInRange,
+                                                    elevation = elevation
                                                 )
-                                            },
-                                            supersetPartnerIndices = partnerIndices,
-                                            isDraggingPartner = isDraggingPartner,
-                                            isDragTarget = isInRange,
-                                            elevation = elevation
+                                            }
                                         )
                                     }
                                 }
@@ -902,52 +965,80 @@ fun SectionsWithDragDrop(
                                                     )
                                                 )
                                             }
-                                            ReorderableExerciseItem(
-                                                index = index,
-                                                exercise = item,
-                                                onRemove = { removeExercise(item) },
-                                                onMove = {
-                                                    showMoveSheet = true
-                                                    moveSelection.clear(); moveSelection.add(item.id)
-                                                    moveSelectedOption = null; moveCustomName = ""
-                                                },
-                                                modifier = Modifier
-                                                    .alpha(if (dragState.draggingExerciseId == item.id) 0f else 1f)
-                                                    .onGloballyPositioned {
-                                                        val topLeft = it.positionInWindow()
-                                                        val size = it.size.toSize()
-                                                        dragState.itemBounds[item.id] =
-                                                            topLeft.y to (topLeft.y + size.height)
-                                                    },
-                                                dragHandle = {
-                                                    var handleOffset by remember {
-                                                        mutableStateOf(
-                                                            Offset.Zero
+                                            val dismissState = rememberDismissState(confirmStateChange = { value ->
+                                                if (value == DismissValue.DismissedToStart) {
+                                                    removeExercise(item)
+                                                    true
+                                                } else {
+                                                    false
+                                                }
+                                            })
+                                            SwipeToDismiss(
+                                                state = dismissState,
+                                                directions = if (dragState.isDragging) emptySet() else setOf(DismissDirection.EndToStart),
+                                                background = {
+                                                    Box(
+                                                        Modifier
+                                                            .fillMaxSize()
+                                                            .background(Color.Red)
+                                                            .padding(horizontal = 20.dp),
+                                                        contentAlignment = Alignment.CenterEnd
+                                                    ) {
+                                                        Icon(
+                                                            imageVector = Icons.Default.Delete,
+                                                            contentDescription = null,
+                                                            tint = Color.White
                                                         )
                                                     }
-                                                    Icon(
-                                                        imageVector = Icons.Default.DragHandle,
-                                                        contentDescription = stringResource(R.string.reorder_movement),
-                                                        tint = Color.Gray,
-                                                        modifier = Modifier
-                                                            .onGloballyPositioned {
-                                                                if (!dragState.isDragging) {
-                                                                    handleOffset =
-                                                                        it.positionInWindow()
-                                                                }
-                                                            }
-                                                            .then(
-                                                                dragModifier(
-                                                                    item.id,
-                                                                    item.name,
-                                                                    item.section,
-                                                                    { handleOffset }) { })
-                                                    )
                                                 },
-                                                supersetPartnerIndices = partnerIndices,
-                                                isDraggingPartner = isDraggingPartner,
-                                                isDragTarget = isInRange,
-                                                elevation = elevation
+                                                dismissContent = {
+                                                    ReorderableExerciseItem(
+                                                        index = index,
+                                                        exercise = item,
+                                                        onMove = {
+                                                            showMoveSheet = true
+                                                            moveSelection.clear(); moveSelection.add(item.id)
+                                                            moveSelectedOption = null; moveCustomName = ""
+                                                        },
+                                                        modifier = Modifier
+                                                            .alpha(if (dragState.draggingExerciseId == item.id) 0f else 1f)
+                                                            .onGloballyPositioned {
+                                                                val topLeft = it.positionInWindow()
+                                                                val size = it.size.toSize()
+                                                                dragState.itemBounds[item.id] =
+                                                                    topLeft.y to (topLeft.y + size.height)
+                                                            },
+                                                        dragHandle = {
+                                                            var handleOffset by remember {
+                                                                mutableStateOf(
+                                                                    Offset.Zero
+                                                                )
+                                                            }
+                                                            Icon(
+                                                                imageVector = Icons.Default.DragHandle,
+                                                                contentDescription = stringResource(R.string.reorder_movement),
+                                                                tint = Color.Gray,
+                                                                modifier = Modifier
+                                                                    .onGloballyPositioned {
+                                                                        if (!dragState.isDragging) {
+                                                                            handleOffset =
+                                                                                it.positionInWindow()
+                                                                        }
+                                                                    }
+                                                                    .then(
+                                                                        dragModifier(
+                                                                            item.id,
+                                                                            item.name,
+                                                                            item.section,
+                                                                            { handleOffset }) { })
+                                                            )
+                                                        },
+                                                        supersetPartnerIndices = partnerIndices,
+                                                        isDraggingPartner = isDraggingPartner,
+                                                        isDragTarget = isInRange,
+                                                        elevation = elevation
+                                                    )
+                                                }
                                             )
                                         }
                                     }


### PR DESCRIPTION
## Summary
- Wrap exercise rows in `SwipeToDismiss` to allow left swipe removal with undo
- Remove trash icon button from `ReorderableExerciseItem` for a cleaner row
- Fix swipe dismiss state confirmation to invoke existing remove logic

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689867b5cb10832a8607572b27d93414