### PR TITLE
Refine line editor typography and interactions

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/GaeguButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/GaeguButton.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.theme.AppTypography
 import com.example.mygymapp.R
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
@@ -45,7 +45,7 @@ fun GaeguButton(
     modifier: Modifier = Modifier,
     textColor: Color = Color.Black,
     fontSize: TextUnit = 18.sp,
-    font: FontFamily = GaeguBold,
+    font: FontFamily = AppTypography.GaeguBold,
     imageRes: Int = R.drawable.button_page, // PNG muss in res/drawable
     contentPadding: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 12.dp),
     icon: (@Composable () -> Unit)? = null

--- a/app/src/main/java/com/example/mygymapp/ui/components/PoeticDivider.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/PoeticDivider.kt
@@ -15,8 +15,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.mygymapp.ui.theme.AppColors
 import com.example.mygymapp.ui.theme.AppPadding
-import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.theme.AppTypography
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun PoeticDivider(
@@ -44,7 +45,14 @@ fun PoeticDivider(
 
         if (centerText != null) {
             Spacer(Modifier.width(AppPadding.Small))
-            Text(centerText, fontFamily = GaeguBold, fontSize = 20.sp, color = Color.Black)
+            Text(
+                centerText,
+                fontFamily = AppTypography.GaeguBold,
+                fontSize = 18.sp,
+                color = Color.Black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
             Spacer(Modifier.width(AppPadding.Small))
             Divider(
                 color = AppColors.SectionLine,

--- a/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ReorderableExerciseItem.kt
@@ -10,9 +10,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.ui.draw.alpha
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AttachFile
-import androidx.compose.material3.Icon
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,10 +22,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.model.Exercise as LineExercise
-import com.example.mygymapp.ui.pages.GaeguBold
-import com.example.mygymapp.ui.pages.GaeguRegular
+import com.example.mygymapp.ui.theme.AppTypography
+import com.example.mygymapp.ui.theme.AppColors
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.unit.IntOffset
 import com.example.mygymapp.ui.motion.MotionSpec
 
@@ -47,8 +43,6 @@ fun LazyItemScope.ReorderableExerciseItem(
 ) {
     val indices = (listOf(index) + supersetPartnerIndices).sorted()
     val isSuperset = supersetPartnerIndices.isNotEmpty()
-    val isFirst = isSuperset && index == indices.first()
-    val isLast = isSuperset && index == indices.last()
 
     Row(
         modifier = modifier
@@ -58,16 +52,12 @@ fun LazyItemScope.ReorderableExerciseItem(
     ) {
         if (isSuperset) {
             Box(
-                modifier = Modifier.width(16.dp).fillMaxHeight(),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Default.AttachFile,
-                    contentDescription = "Superset",
-                    tint = Color.Gray,
-                    modifier = Modifier.rotate(90f)
-                )
-            }
+                modifier = Modifier
+                    .width(4.dp)
+                    .fillMaxHeight()
+                    .background(AppColors.SectionLine.copy(alpha = 0.5f))
+            )
+            Spacer(Modifier.width(12.dp))
         } else {
             Spacer(Modifier.width(16.dp))
         }
@@ -83,15 +73,10 @@ fun LazyItemScope.ReorderableExerciseItem(
             targetValue = when {
                 isDragTarget -> Color(0xFF2E7D32)
                 isDraggingPartner -> Color(0xFFFBC02D)
-                isSuperset -> Color(0xFFFFF59D)
                 else -> Color.Transparent
             }, animationSpec = MotionSpec.tweenMedium()
         )
-        val backgroundBrush = if (isSuperset) {
-            Brush.verticalGradient(listOf(Color(0xFFFDF6EC), Color(0xFFE8F5E9)))
-        } else {
-            Brush.verticalGradient(listOf(highlightColor, highlightColor))
-        }
+        val backgroundBrush = Brush.verticalGradient(listOf(highlightColor, highlightColor))
         val isDragging = elevation > 2.dp
         val scale by animateFloatAsState(
             targetValue = if (isDragging) 1.02f else 1f,
@@ -135,14 +120,14 @@ fun LazyItemScope.ReorderableExerciseItem(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
                                 text = "${index + 1}.",
-                                fontFamily = GaeguBold,
+                                fontFamily = AppTypography.GaeguBold,
                                 fontSize = 16.sp,
                                 color = Color.Black,
                                 modifier = Modifier.padding(end = 8.dp)
                             )
                             Text(
                                 text = exercise.name,
-                                fontFamily = GaeguRegular,
+                                fontFamily = AppTypography.GaeguRegular,
                                 fontSize = 16.sp,
                                 color = Color.Black
                             )
@@ -152,7 +137,7 @@ fun LazyItemScope.ReorderableExerciseItem(
                             TextButton(onClick = onMove) {
                                 Text(
                                     "Move",
-                                    fontFamily = GaeguRegular,
+                                    fontFamily = AppTypography.GaeguRegular,
                                     fontSize = 14.sp,
                                     color = Color.Black
                                 )

--- a/app/src/main/java/com/example/mygymapp/ui/components/WaxSealButton.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/WaxSealButton.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.mygymapp.R
-import com.example.mygymapp.ui.pages.GaeguBold
+import com.example.mygymapp.ui.theme.AppTypography
 
 /**
  * A poetic action button using a wax seal illustration.
@@ -36,7 +36,7 @@ fun WaxSealButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     imageRes: Int = R.drawable.waxseal,
-    font: FontFamily = GaeguBold,
+    font: FontFamily = AppTypography.GaeguBold,
     textColor: Color = Color.White,
     textSize: TextUnit = 16.sp,
     shadowColor: Color = Color.Black,

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.toSize
@@ -50,6 +49,9 @@ import com.example.mygymapp.data.Exercise
 import com.example.mygymapp.model.Exercise as LineExercise
 import com.example.mygymapp.ui.components.*
 import com.example.mygymapp.ui.motion.MotionSpec
+import com.example.mygymapp.ui.theme.AppTypography
+import com.example.mygymapp.ui.theme.AppColors
+import androidx.compose.ui.text.style.TextOverflow
 import android.widget.Toast
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -143,6 +145,7 @@ private fun moveWithSuperset(
 }
 
 /** Unified drag handler used by picker items and list handles. */
+@Composable
 fun Modifier.exerciseDrag(
     state: DragAndDropState,
     exerciseId: Long,
@@ -290,7 +293,7 @@ fun ExercisePickerSheet(
     allExercises: List<Exercise>,
     selectedMuscles: List<String>,
     dragState: DragAndDropState,
-    dragModifier: (Long, String, String, () -> Offset, () -> Unit) -> Modifier,
+    dragModifier: @Composable (Long, String, String, () -> Offset, () -> Unit) -> Modifier,
     onExerciseClicked: (Exercise) -> Unit,
     onCreateExercise: (String) -> Unit,
     onDismiss: () -> Unit
@@ -347,7 +350,7 @@ fun ExercisePickerSheet(
                 Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
                     Text(
                         "No matching exercises found.",
-                        fontFamily = GaeguLight,
+                        fontFamily = AppTypography.GaeguLight,
                         fontSize = 14.sp,
                         color = Color.Black,
                         modifier = Modifier.padding(12.dp)
@@ -376,10 +379,10 @@ fun ExercisePickerSheet(
                                     selectedFilter.value = null
                                 }
                         ) {
-                            Text(ex.name, fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
+                            Text(ex.name, fontFamily = AppTypography.GaeguRegular, fontSize = 16.sp, color = Color.Black)
                             Text(
                                 "${ex.muscleGroup.display} · ${ex.category.display}",
-                                fontFamily = GaeguLight,
+                                fontFamily = AppTypography.GaeguLight,
                                 fontSize = 13.sp,
                                 color = Color.Black
                             )
@@ -399,7 +402,7 @@ fun SectionsWithDragDrop(
     supersetState: SupersetState,
     dragState: DragAndDropState,
     allExercises: List<Exercise>,
-    dragModifier: (Long, String, String, () -> Offset, () -> Unit) -> Modifier,
+    dragModifier: @Composable (Long, String, String, () -> Offset, () -> Unit) -> Modifier,
     findInsertIndexForDrop: (String, Float) -> Int,
     snackbarHostState: SnackbarHostState
 ) {
@@ -484,7 +487,7 @@ fun SectionsWithDragDrop(
                         Checkbox(checked = checked, onCheckedChange = null)
                         Text(
                             ex.name,
-                            fontFamily = GaeguRegular,
+                            fontFamily = AppTypography.GaeguRegular,
                             color = Color.Black,
                             modifier = Modifier.padding(start = 8.dp)
                         )
@@ -616,14 +619,9 @@ fun SectionsWithDragDrop(
                 }
         ) {
             if (sections.isEmpty()) {
-                Text("Today's selected movements:", fontFamily = GaeguBold, color = Color.Black)
                 val reorderState = rememberReorderableLazyListState(onMove = { from, to ->
                     moveWithSuperset(selectedExercises, supersetState, from.index, to.index)
                 })
-                val isDropActive = dragState.hoveredSection == ""
-                val bgColor by animateColorAsState(if (isDropActive) Color(0xFFF5F5DC) else Color.Transparent)
-                val borderColor by animateColorAsState(if (isDropActive) Color(0xFFE0DCC8) else Color.Transparent)
-                val extraPadding by animateDpAsState(if (isDropActive) 8.dp else 0.dp)
                 Box(
                     modifier = Modifier
                         .onGloballyPositioned {
@@ -631,10 +629,6 @@ fun SectionsWithDragDrop(
                             val bottom = top + it.size.height
                             dragState.sectionBounds[""] = top to bottom
                         }
-                        .background(bgColor)
-                        .border(1.dp, borderColor)
-                        .shadow(if (isDropActive) 4.dp else 0.dp)
-                        .padding(vertical = extraPadding)
                         .fillMaxWidth()
                 ) {
                     LazyColumn(
@@ -645,10 +639,24 @@ fun SectionsWithDragDrop(
                             .detectReorderAfterLongPress(reorderState)
                             .fillMaxWidth(),
                         userScrollEnabled = false
-                    ) {
-                        itemsIndexed(
-                            selectedExercises,
-                            key = { _, item -> item.id }) { index, item ->
+                      ) {
+                          stickyHeader {
+                            Text(
+                                text = "Today's selected movements:",
+                                style = AppTypography.Title.copy(fontSize = 20.sp, color = AppColors.SubtleText),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(AppColors.Paper)
+                                    .padding(vertical = 8.dp),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                          }
+                          item { Spacer(Modifier.height(8.dp)) }
+                          itemsIndexed(
+                              selectedExercises,
+                              key = { _, item -> item.id }
+                          ) { index, item ->
                             ReorderableItem(reorderState, key = item.id) { dragging ->
                                 val elevation = if (dragging) 8.dp else 2.dp
                                 val partnerIndices =
@@ -666,7 +674,7 @@ fun SectionsWithDragDrop(
                                     if (caption != null) {
                                         Text(
                                             caption,
-                                            fontFamily = GaeguRegular,
+                                            fontFamily = AppTypography.GaeguRegular,
                                             color = Color.Gray,
                                             modifier = Modifier.padding(
                                                 start = 32.dp,
@@ -830,7 +838,7 @@ fun SectionsWithDragDrop(
                                         if (caption != null) {
                                             Text(
                                                 caption,
-                                                fontFamily = GaeguRegular,
+                                                fontFamily = AppTypography.GaeguRegular,
                                                 color = Color.Gray,
                                                 modifier = Modifier.padding(
                                                     start = 32.dp,
@@ -957,7 +965,7 @@ fun SectionsWithDragDrop(
                             ) {
                                 Text(
                                     "Drop a movement here",
-                                    fontFamily = GaeguRegular,
+                                    fontFamily = AppTypography.GaeguRegular,
                                     color = Color.Gray
                                 )
                             }
@@ -1002,7 +1010,7 @@ fun SectionsWithDragDrop(
                                             if (caption != null) {
                                                 Text(
                                                     caption,
-                                                    fontFamily = GaeguRegular,
+                                                    fontFamily = AppTypography.GaeguRegular,
                                                     color = Color.Gray,
                                                     modifier = Modifier.padding(
                                                         start = 32.dp,

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -19,12 +19,14 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.keyframes
@@ -41,6 +43,7 @@ import com.example.mygymapp.ui.components.PoeticCard
 import com.example.mygymapp.R
 import com.example.mygymapp.viewmodel.ExerciseViewModel
 import com.example.mygymapp.viewmodel.LineEditorViewModel
+import com.example.mygymapp.ui.theme.AppTypography
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
@@ -93,22 +96,21 @@ fun LineEditorPage(
         return if (dropY >= center) closest.index + 1 else closest.index
     }
 
-    val dragModifier = remember(allExercises, selectedExercises, supersetState) {
-        { id: Long, name: String, section: String, offset: () -> Offset, start: () -> Unit ->
+    val dragModifier: @Composable (Long, String, String, () -> Offset, () -> Unit) -> Modifier =
+        { id, name, section, offset, start ->
             Modifier.exerciseDrag(
-                dragState,
-                id,
-                name,
-                section,
-                offset,
-                allExercises,
-                selectedExercises,
-                supersetState,
-                ::findInsertIndexForDrop,
-                start
+                state = dragState,
+                exerciseId = id,
+                exerciseName = name,
+                startSection = section,
+                getStartOffset = offset,
+                allExercises = allExercises,
+                selectedExercises = selectedExercises,
+                supersetState = supersetState,
+                findInsertIndex = ::findInsertIndexForDrop,
+                onStart = start
             )
         }
-    }
 
     var saving by remember { mutableStateOf(false) }
     var pendingLine by remember { mutableStateOf<Line?>(null) }
@@ -154,7 +156,13 @@ fun LineEditorPage(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     item(key = "header") {
-                        Text(stringResource(R.string.compose_daily_line), fontFamily = GaeguBold, fontSize = 24.sp, color = Color.Black)
+                        Text(
+                            text = stringResource(R.string.compose_daily_line),
+                            style = AppTypography.Title,
+                            color = Color.Black,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                     item(key = "details") {
                         val titleError = showError && title.isBlank()
@@ -237,19 +245,22 @@ fun LineEditorPage(
                         }
                     }
                     item(key = "divider_end") { PoeticDivider() }
-                    item(key = "actions") {
-                        Box(modifier = Modifier.fillMaxWidth()) {
-                            GaeguButton(
-                                text = stringResource(R.string.cancel),
-                                onClick = onCancel,
-                                textColor = Color.Black,
-                                modifier = Modifier.align(Alignment.CenterStart)
-                            )
-                            WaxSealButton(
-                                label = stringResource(R.string.create_line),
-                                enabled = title.isNotBlank() && selectedExercises.isNotEmpty(),
-                                onClick = {
-                                    if (title.isBlank() || selectedExercises.isEmpty()) {
+                      item(key = "actions") {
+                          val canSave = title.isNotBlank() && selectedExercises.isNotEmpty()
+                          val cancelLabel = stringResource(R.string.cancel)
+                          Box(modifier = Modifier.fillMaxWidth()) {
+                              GaeguButton(
+                                  text = cancelLabel,
+                                  onClick = onCancel,
+                                  textColor = Color.Black,
+                                  modifier = Modifier
+                                      .align(Alignment.CenterStart)
+                                      .semantics { contentDescription = cancelLabel }
+                              )
+                              WaxSealButton(
+                                  label = stringResource(R.string.create_line),
+                                  onClick = {
+                                    if (!canSave) {
                                         showError = true
                                         scope.launch {
                                             if (title.isBlank()) {
@@ -264,7 +275,9 @@ fun LineEditorPage(
                                     pendingLine = editorVm.buildLine()
                                     saving = true
                                 },
-                                modifier = Modifier.align(Alignment.Center)
+                                modifier = Modifier
+                                    .align(Alignment.Center)
+                                    .alpha(if (canSave) 1f else 0.5f)
                             )
                         }
                     }
@@ -289,11 +302,11 @@ fun LineEditorPage(
                     ) {
                         PoeticCard(tintOverlayAlpha = 0.3f) {
                             Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-                                Text(name, fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
+                                Text(name, fontFamily = AppTypography.GaeguRegular, fontSize = 16.sp, color = Color.Black)
                                 lineExercise?.let {
                                     Text(
                                         stringResource(R.string.sets_reps_format, it.sets, it.repsOrDuration),
-                                        fontFamily = GaeguRegular,
+                                        fontFamily = AppTypography.GaeguRegular,
                                         fontSize = 12.sp,
                                         color = Color.Black
                                     )

--- a/app/src/main/java/com/example/mygymapp/ui/theme/Typography.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/theme/Typography.kt
@@ -1,44 +1,20 @@
 package com.example.mygymapp.ui.theme
 
 import androidx.compose.material3.Typography
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-val Lora = FontFamily.Serif
 
-val WorkSans = FontFamily.SansSerif
-
-val Handwriting = FontFamily.Cursive
-
+// Use only Gaegu fonts defined in DesignSystem
 val handwritingText = TextStyle(
-    fontFamily = Handwriting,
+    fontFamily = AppTypography.GaeguRegular,
     fontSize = 16.sp,
     lineHeight = 24.sp
 )
 
 val MyGymTypography = Typography(
-    headlineSmall = TextStyle(
-        fontFamily = Lora,
-        fontWeight = FontWeight.Medium,
-        fontSize = 22.sp,
-        lineHeight = 30.sp
-    ),
-    labelLarge = TextStyle(
-        fontFamily = WorkSans,
-        fontWeight = FontWeight.Medium,
-        fontSize = 14.sp,
-        letterSpacing = 1.1.sp
-    ),
-    bodyMedium = TextStyle(
-        fontFamily = WorkSans,
-        fontSize = 15.sp,
-        lineHeight = 22.sp
-    ),
-    bodySmall = TextStyle(
-        fontFamily = WorkSans,
-        fontSize = 13.sp,
-        color = Color.Gray
-    )
+    headlineSmall = AppTypography.Title,
+    titleMedium = AppTypography.Title.copy(fontSize = 20.sp),
+    bodyMedium = AppTypography.Body,
+    bodySmall = AppTypography.Hint,
+    labelLarge = AppTypography.Button
 )


### PR DESCRIPTION
## Summary
- Replace Material typography with Gaegu-based styles from `DesignSystem`
- Move "Today's selected movements" into a padded sticky header and remove drag hover highlight
- Clean up superset visuals and wire cancel/save actions with validation feedback
- Mark drag helper as `@Composable` to fix build error
- Ensure drag helper and cancel semantics are invoked from valid composable contexts
- Accept composable drag modifier in picker and drag-drop sections

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68987a8cece0832a9091e3d7b89c103a