### PR TITLE
refactor editor for derived state and a11y

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
@@ -746,7 +746,7 @@ fun SectionsWithDragDrop(
                                                     var handleOffset by remember { mutableStateOf(Offset.Zero) }
                                                     Icon(
                                                         imageVector = Icons.Default.DragHandle,
-                                                        contentDescription = stringResource(R.string.reorder_movement),
+                                                        contentDescription = stringResource(R.string.reorder_movement, item.name),
                                                         tint = Color.Gray,
                                                         modifier = Modifier
                                                             .onGloballyPositioned {
@@ -911,7 +911,7 @@ fun SectionsWithDragDrop(
                                         var handleOffset by remember { mutableStateOf(Offset.Zero) }
                                         Icon(
                                             imageVector = Icons.Default.DragHandle,
-                                            contentDescription = stringResource(R.string.reorder_movement),
+                                            contentDescription = stringResource(R.string.reorder_movement, item.name),
                                             tint = Color.Gray,
                                             modifier = Modifier
                                                 .onGloballyPositioned {
@@ -1084,9 +1084,9 @@ fun SectionsWithDragDrop(
                                                                     Offset.Zero
                                                                 )
                                                             }
-                                                            Icon(
-                                                                imageVector = Icons.Default.DragHandle,
-                                                                contentDescription = stringResource(R.string.reorder_movement),
+                                                                Icon(
+                                                                    imageVector = Icons.Default.DragHandle,
+                                                                    contentDescription = stringResource(R.string.reorder_movement, item.name),
                                                                 tint = Color.Gray,
                                                                 modifier = Modifier
                                                                     .onGloballyPositioned {

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorPage.kt
@@ -117,6 +117,23 @@ fun LineEditorPage(
     val saveOffset = remember { Animatable(0f) }
     val saveAlpha = remember { Animatable(1f) }
 
+    val newLineLabel = stringResource(R.string.new_line)
+    val headerText by remember(title, newLineLabel) {
+        derivedStateOf { if (title.isBlank()) initial?.title ?: newLineLabel else title }
+    }
+
+    val canSave by remember(title, selectedExercises) {
+        derivedStateOf { title.isNotBlank() && selectedExercises.isNotEmpty() }
+    }
+
+    val titleError by remember(showError, title) {
+        derivedStateOf { showError && title.isBlank() }
+    }
+
+    val exerciseError by remember(showError, selectedExercises) {
+        derivedStateOf { showError && selectedExercises.isEmpty() }
+    }
+
     LaunchedEffect(saving) {
         val line = pendingLine
         if (saving && line != null) {
@@ -155,17 +172,16 @@ fun LineEditorPage(
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    item(key = "header") {
+                    item(key = "header", contentType = "header") {
                         Text(
-                            text = stringResource(R.string.compose_daily_line),
+                            text = headerText,
                             style = AppTypography.Title,
                             color = Color.Black,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                     }
-                    item(key = "details") {
-                        val titleError = showError && title.isBlank()
+                    item(key = "details", contentType = "details") {
                         LineTitleAndCategoriesSection(
                             title = title,
                             onTitleChange = { editorVm.title.value = it },
@@ -179,17 +195,17 @@ fun LineEditorPage(
                             titleBringIntoViewRequester = titleBringIntoViewRequester
                         )
                     }
-                    item(key = "notes") {
+                    item(key = "notes", contentType = "notes") {
                         LineNotesSection(
                             note = note,
                             onNoteChange = { editorVm.note.value = it },
                             noteBringIntoViewRequester = noteBringIntoViewRequester
                         )
                     }
-                    stickyHeader {
+                    stickyHeader(key = "movements_header", contentType = "stickyHeader") {
                         PoeticDivider(centerText = stringResource(R.string.movements_prompt))
                     }
-                    item(key = "picker") {
+                    item(key = "picker", contentType = "picker") {
                         GaeguButton(text = stringResource(R.string.add_exercise_button), onClick = { showExerciseSheet.value = true }, textColor = Color.Black)
                         ExercisePickerSheet(
                             visible = showExerciseSheet.value,
@@ -207,8 +223,7 @@ fun LineEditorPage(
                             onDismiss = { showExerciseSheet.value = false }
                         )
                     }
-                    item(key = "exercise_list") {
-                        val exerciseError = showError && selectedExercises.isEmpty()
+                    item(key = "exercise_list", contentType = "exercise_list") {
                         val exerciseShake by animateFloatAsState(
                             if (exerciseShakeTrigger) 8f else 0f,
                             animationSpec = keyframes {
@@ -244,10 +259,10 @@ fun LineEditorPage(
                             )
                         }
                     }
-                    item(key = "divider_end") { PoeticDivider() }
-                      item(key = "actions") {
-                          val canSave = title.isNotBlank() && selectedExercises.isNotEmpty()
+                    item(key = "divider_end", contentType = "divider") { PoeticDivider() }
+                    item(key = "actions", contentType = "actions") {
                           val cancelLabel = stringResource(R.string.cancel)
+                          val saveLabel = stringResource(R.string.create_line)
                           Box(modifier = Modifier.fillMaxWidth()) {
                               GaeguButton(
                                   text = cancelLabel,
@@ -258,7 +273,7 @@ fun LineEditorPage(
                                       .semantics { contentDescription = cancelLabel }
                               )
                               WaxSealButton(
-                                  label = stringResource(R.string.create_line),
+                                  label = saveLabel,
                                   onClick = {
                                     if (!canSave) {
                                         showError = true
@@ -278,6 +293,8 @@ fun LineEditorPage(
                                 modifier = Modifier
                                     .align(Alignment.Center)
                                     .alpha(if (canSave) 1f else 0.5f)
+                                    .semantics { contentDescription = saveLabel },
+                                enabled = canSave
                             )
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,7 +126,8 @@
     <string name="nav_library">Exercises</string>
     <string name="nav_plan">Plan</string>
     <string name="nav_profile">Profile</string>
-        <string name="progress_muscle_groups">Muscle Groups</string>
+    <string name="progress_muscle_groups">Muscle Groups</string>
+    <string name="new_line">New Line</string>
     <string name="compose_daily_line">✎ Compose your daily line</string>
     <string name="movements_prompt">Which movements do you want to add?</string>
     <string name="create_line">Create</string>
@@ -160,7 +161,7 @@
     <string name="save_paragraph_cd">Save paragraph</string>
     <string name="line_item_cd">Select line %1$s</string>
     <string name="undo">Undo</string>
-    <string name="reorder_movement">Reorder movement</string>
+    <string name="reorder_movement">Drag to reorder %1$s</string>
     <string name="drop_zone_for">Drop zone for %1$s</string>
     <string name="drop_zone_hovered">current drop target</string>
     <string name="sets_reps_format">%1$d x %2$s</string>


### PR DESCRIPTION
## Summary
- derive Line Editor header and save state for smoother recomposition
- add stable keys/content types and accessible labels on actions
- give drag handles descriptive content descriptions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689886b41e1c832aac5327f2468b5fe1