### PR TITLE
Add hysteresis to SupersetRangeSelector for stable range selection

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/SupersetRangeSelector.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/SupersetRangeSelector.kt
@@ -1,5 +1,6 @@
 package com.example.mygymapp.ui.pages
 
+import android.content.res.Resources
 import androidx.compose.ui.geometry.Offset
 
 /** Snapshot of an active or completed range selection. */
@@ -21,17 +22,29 @@ data class PointerInfo(val id: Long, val position: Offset)
 class SupersetRangeSelector(private val itemBounds: Map<Long, Pair<Float, Float>>) {
     private var firstPointer: Long? = null
     private var secondPointer: Long? = null
+    private var startAnchorId: Long? = null
+    private var endAnchorId: Long? = null
     private var activeSelection: SupersetRangeSelection? = null
     private var initialDistance: Float? = null
     private var currentDistance: Float = 0f
+    private val hysteresisPx = 20f * Resources.getSystem().displayMetrics.density
+    private val outResetDelayMs = 150L
+    private val boundsTop = itemBounds.values.minOfOrNull { it.first } ?: 0f
+    private val boundsBottom = itemBounds.values.maxOfOrNull { it.second } ?: 0f
+    private var firstOutTime: Long? = null
+    private var secondOutTime: Long? = null
 
     /** Reset internal tracking. */
     fun reset() {
         firstPointer = null
         secondPointer = null
+        startAnchorId = null
+        endAnchorId = null
         activeSelection = null
         initialDistance = null
         currentDistance = 0f
+        firstOutTime = null
+        secondOutTime = null
     }
 
     /**
@@ -52,43 +65,67 @@ class SupersetRangeSelector(private val itemBounds: Map<Long, Pair<Float, Float>
         }
 
         if (firstPointer == null && pointers.isNotEmpty()) {
-            firstPointer = pointers.first().id
+            val p = pointers.first()
+            firstPointer = p.id
+            startAnchorId = idAt(p.position.y)
         }
-        if (firstPointer != null && secondPointer == null && pointers.size == 2) {
-            secondPointer = pointers.firstOrNull { it.id != firstPointer }?.id
+        if (firstPointer != null && secondPointer == null && pointers.size >= 2) {
+            val p = pointers.firstOrNull { it.id != firstPointer }
+            if (p != null) {
+                secondPointer = p.id
+                endAnchorId = idAt(p.position.y)
+            }
         }
-
-        if (pointers.size < 2 || firstPointer == null || secondPointer == null) {
-            return null
-        }
-
-        val firstPos = pointers.firstOrNull { it.id == firstPointer }?.position
-        val secondPos = pointers.firstOrNull { it.id == secondPointer }?.position
-
-        if (firstPos == null || secondPos == null) {
-            activeSelection = null
-            return null
-        }
-
-        currentDistance = kotlin.math.abs(firstPos.y - secondPos.y)
-        if (initialDistance == null) initialDistance = currentDistance
-
-        val boundsTop = itemBounds.values.minOfOrNull { it.first } ?: return null
-        val boundsBottom = itemBounds.values.maxOfOrNull { it.second } ?: return null
-        if (firstPos.y !in boundsTop..boundsBottom || secondPos.y !in boundsTop..boundsBottom) {
-            activeSelection = null
-            return null
-        }
-
-        val startId = idAt(firstPos.y) ?: return null
-        val endId = idAt(secondPos.y) ?: return null
 
         val sorted = itemBounds.entries.sortedBy { it.value.first }
-        val startIdx = sorted.indexOfFirst { it.key == startId }
-        val endIdx = sorted.indexOfFirst { it.key == endId }
-        if (startIdx == -1 || endIdx == -1) return null
+        val sortedIds = sorted.map { it.key }
+        val idToIndex = sortedIds.withIndex().associate { it.value to it.index }
+
+        val now = System.currentTimeMillis()
+
+        val firstPos = pointers.firstOrNull { it.id == firstPointer }?.position
+        if (firstPos != null) {
+            firstOutTime = if (firstPos.y < boundsTop || firstPos.y > boundsBottom) {
+                firstOutTime ?: now
+            } else {
+                null
+            }
+            startAnchorId = updateAnchor(startAnchorId, firstPos.y, sortedIds, idToIndex)
+        }
+
+        val secondPos = pointers.firstOrNull { it.id == secondPointer }?.position
+        if (secondPos != null) {
+            secondOutTime = if (secondPos.y < boundsTop || secondPos.y > boundsBottom) {
+                secondOutTime ?: now
+            } else {
+                null
+            }
+            endAnchorId = updateAnchor(endAnchorId, secondPos.y, sortedIds, idToIndex)
+        }
+
+        if (firstPos != null && secondPos != null) {
+            currentDistance = kotlin.math.abs(firstPos.y - secondPos.y)
+            if (initialDistance == null) initialDistance = currentDistance
+        }
+
+        if (firstOutTime != null && secondOutTime != null) {
+            if ((now - firstOutTime!!) > outResetDelayMs && (now - secondOutTime!!) > outResetDelayMs) {
+                val result = activeSelection
+                reset()
+                return result
+            }
+        }
+
+        val startId = startAnchorId
+        val endId = endAnchorId
+        if (startId == null || endId == null) {
+            return activeSelection
+        }
+
+        val startIdx = idToIndex[startId] ?: return activeSelection
+        val endIdx = idToIndex[endId] ?: return activeSelection
         val range = if (startIdx <= endIdx) startIdx..endIdx else endIdx..startIdx
-        val ids = range.map { sorted[it].key }
+        val ids = range.map { sortedIds[it] }
         val selection = SupersetRangeSelection(startId, endId, ids)
         activeSelection = selection
         return selection
@@ -106,7 +143,57 @@ class SupersetRangeSelector(private val itemBounds: Map<Long, Pair<Float, Float>
         get() = currentDistance
 
     private fun idAt(y: Float): Long? {
-        return itemBounds.entries.firstOrNull { y >= it.value.first && y <= it.value.second }?.key
+        if (itemBounds.isEmpty()) return null
+        val first = itemBounds.minByOrNull { it.value.first } ?: return null
+        val last = itemBounds.maxByOrNull { it.value.second } ?: return null
+        return when {
+            y < first.value.first -> first.key
+            y > last.value.second -> last.key
+            else -> itemBounds.entries.firstOrNull { y >= it.value.first && y <= it.value.second }?.key
+        }
+    }
+
+    private fun updateAnchor(
+        currentId: Long?,
+        y: Float,
+        sortedIds: List<Long>,
+        idToIndex: Map<Long, Int>
+    ): Long? {
+        var id = currentId ?: idAt(y) ?: return null
+        var index = idToIndex[id] ?: return id
+        while (true) {
+            val bounds = itemBounds[id] ?: break
+            if (y < bounds.first) {
+                val prevIndex = index - 1
+                if (prevIndex < 0) break
+                val prevId = sortedIds[prevIndex]
+                val prevBounds = itemBounds[prevId] ?: break
+                val threshold = (prevBounds.first + prevBounds.second) / 2f - hysteresisPx
+                if (y < threshold) {
+                    id = prevId
+                    index = prevIndex
+                    continue
+                } else {
+                    break
+                }
+            } else if (y > bounds.second) {
+                val nextIndex = index + 1
+                if (nextIndex >= sortedIds.size) break
+                val nextId = sortedIds[nextIndex]
+                val nextBounds = itemBounds[nextId] ?: break
+                val threshold = (nextBounds.first + nextBounds.second) / 2f + hysteresisPx
+                if (y > threshold) {
+                    id = nextId
+                    index = nextIndex
+                    continue
+                } else {
+                    break
+                }
+            } else {
+                break
+            }
+        }
+        return id
     }
 }
 


### PR DESCRIPTION
## Summary
- Anchor initial start/end items and apply hysteresis to prevent jitter
- Track Y-only movement and maintain selection while any finger remains
- Hold selection briefly when fingers leave list and clamp to edges before finalizing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898f6745698832a81ddce84ead35c4c