### PR TITLE
Introduce superset split API with dynamic commit threshold

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
@@ -119,6 +119,27 @@ class SupersetState(private val supersets: SnapshotStateList<MutableList<Long>>)
         supersets.removeAll { group -> ids.all { it in group } }
     }
 
+    /**
+     * Split an existing group by removing the contiguous [rangeIds] segment and
+     * adding back the remaining left/right segments when they contain two or
+     * more items. If [rangeIds] spans the entire group the group is simply
+     * removed.
+     */
+    fun splitGroupAtRange(rangeIds: List<Long>) {
+        if (rangeIds.isEmpty()) return
+        val group = supersets.firstOrNull { rangeIds.all { id -> id in it } } ?: return
+        val startIdx = group.indexOf(rangeIds.first())
+        val endIdx = group.indexOf(rangeIds.last())
+        if (startIdx == -1 || endIdx == -1) return
+        val from = minOf(startIdx, endIdx)
+        val to = maxOf(startIdx, endIdx)
+        val left = group.subList(0, from).toList()
+        val right = group.subList(to + 1, group.size).toList()
+        supersets.remove(group)
+        if (left.size >= 2) supersets.add(left.toMutableList())
+        if (right.size >= 2) supersets.add(right.toMutableList())
+    }
+
     /** Replace all groups with [groups]. */
     fun replaceAll(groups: List<List<Long>>) {
         supersets.clear()
@@ -451,7 +472,7 @@ fun SectionsWithDragDrop(
     var pendingCaption by remember { mutableStateOf<String?>(null) }
     val context = LocalContext.current
     val density = LocalDensity.current
-    val minSplitDistance = with(density) { 48.dp.toPx() }
+    val basePullApartPx = with(density) { 48.dp.toPx() }
 
     LaunchedEffect(Unit) {
         snapshotFlow { rawRangeIds to rawCaption }
@@ -581,10 +602,11 @@ fun SectionsWithDragDrop(
                                 )
                             }
                             val selection = rangeSelector.onPointerEvent(dragState.listTop, pointers)
-                            val groupHeight = selection?.idsInRange?.sumOf { id ->
-                                dragState.itemBounds[id]?.let { (it.second - it.first).toDouble() } ?: 0.0
-                            }?.toFloat() ?: 0f
-                            val thresholdPx = kotlin.math.max(minSplitDistance, 0.35f * groupHeight)
+                            val groupHeight = selection?.idsInRange?.fold(0f) { acc, id ->
+                                val bounds = dragState.itemBounds[id]
+                                acc + (bounds?.let { it.second - it.first } ?: 0f)
+                            } ?: 0f
+                            val thresholdPx = kotlin.math.max(basePullApartPx, 0.35f * groupHeight)
                             val pulledApart = rangeSelector.isOutwardPull(thresholdPx)
                             val timeoutCommit = rangeSelector.shouldCommit()
                             if (active.size == 2 && selection != null && !timeoutCommit) {
@@ -622,19 +644,8 @@ fun SectionsWithDragDrop(
                                             if (sameGroup && pulledApart) {
                                                 val before = supersetState.groups
                                                 val rangeIds = sel.idsInRange
-                                                val exactGroup = supersetState.groups.any { group ->
-                                                    group.size == rangeIds.size && group.containsAll(
-                                                        rangeIds
-                                                    )
-                                                }
                                                 Snapshot.withMutableSnapshot {
-                                                    if (exactGroup) {
-                                                        supersetState.removeGroup(rangeIds)
-                                                    } else {
-                                                        rangeIds.forEach {
-                                                            supersetState.removeExercise(it)
-                                                        }
-                                                    }
+                                                    supersetState.splitGroupAtRange(rangeIds)
                                                 }
                                                 scope.launch {
                                                     val result = snackbarHostState.showSnackbar(


### PR DESCRIPTION
## Summary
- Add `splitGroupAtRange` to `SupersetState` to carve out partial selections into new groups or remove exact matches
- Use the new API in `SectionsWithDragDrop` and rely on `shouldCommit()` timeout as a pointer-up event
- Scale pull-apart detection to `max(48dp, 0.35 * groupHeight)` so splitting adapts to the selected range

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a5802794832aa9a4600faf31b631