### PR TITLE
Refine superset split commit logic

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineEditorComponents.kt
@@ -646,10 +646,18 @@ fun SectionsWithDragDrop(
                                             val sameGroup = supersetState.partners(sel.startId)
                                                 .contains(sel.endId)
                                             if (sameGroup && pulledApart) {
-                                                val before = supersetState.groups
                                                 val rangeIds = sel.idsInRange
+                                                val before = supersetState.groups
+                                                val exactMatch = before.any { group ->
+                                                    group.size == rangeIds.size &&
+                                                        group.containsAll(rangeIds)
+                                                }
                                                 Snapshot.withMutableSnapshot {
-                                                    supersetState.splitGroupAtRange(rangeIds)
+                                                    if (exactMatch) {
+                                                        supersetState.removeGroup(rangeIds)
+                                                    } else {
+                                                        rangeIds.forEach { supersetState.removeExercise(it) }
+                                                    }
                                                 }
                                                 scope.launch {
                                                     val result = snackbarHostState.showSnackbar(


### PR DESCRIPTION
## Summary
- Rework superset split handling to remove whole groups or just the pulled range
- Preserve previous state for undo and apply mutations in a snapshot

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c79078fc832a9acf2b7b02049b05