### PR TITLE
Refine lines and paragraphs pages

### DIFF
--- a/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/LineCard.kt
@@ -51,37 +51,30 @@ fun LineCard(
                 MoodChip(mood = it)
             }
         }
-        Spacer(modifier = Modifier.height(6.dp))
+        Spacer(modifier = Modifier.height(4.dp))
         val supersetWord = if (line.supersets.size == 1) stringResource(R.string.superset_singular) else stringResource(R.string.superset_plural)
         Text(
             text = stringResource(R.string.line_card_summary, line.exercises.size, line.supersets.size, supersetWord),
             style = TextStyle(
                 fontFamily = GaeguRegular,
-                fontSize = 14.sp,
+                fontSize = 13.sp,
                 color = textColor
             )
         )
         if (line.note.isNotBlank()) {
-            Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = stringResource(R.string.note_prefix, line.note),
                 style = TextStyle(
                     fontFamily = GaeguRegular,
-                    fontSize = 14.sp,
+                    fontSize = 13.sp,
                     color = textColor
                 ),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
         }
-        if (line.exercises.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(8.dp))
-            line.exercises.forEach { ex ->
-                ExerciseItem(exercise = ex)
-                Spacer(modifier = Modifier.height(4.dp))
-            }
-        }
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             TextButton(
                 onClick = onEdit,

--- a/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/components/ParagraphCard.kt
@@ -1,13 +1,17 @@
 package com.example.mygymapp.ui.components
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.ui.pages.GaeguBold
 import com.example.mygymapp.ui.pages.GaeguRegular
@@ -23,22 +27,40 @@ fun ParagraphCard(
     modifier: Modifier = Modifier
 ) {
     PoeticCard(modifier = modifier.padding(vertical = 6.dp)) {
+        val textColor = Color(0xFF5D4037)
+        val buttonBackground = Color(0xFFFFF8E1)
         Text(
             text = paragraph.title,
-            style = MaterialTheme.typography.headlineSmall.copy(fontFamily = GaeguBold)
+            style = MaterialTheme.typography.headlineSmall.copy(fontFamily = GaeguBold, fontSize = 24.sp, color = textColor)
         )
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         paragraph.lineTitles.forEachIndexed { index, title ->
             Text(
                 text = "Day ${index + 1}: $title",
-                style = MaterialTheme.typography.bodySmall.copy(fontFamily = GaeguRegular)
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = GaeguRegular, color = textColor),
+                modifier = Modifier.padding(vertical = 2.dp)
             )
         }
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            TextButton(onClick = onEdit) { Text(stringResource(R.string.edit_label), fontFamily = GaeguRegular) }
-            TextButton(onClick = onPlan) { Text(stringResource(R.string.plan_label), fontFamily = GaeguRegular) }
-            TextButton(onClick = onSaveTemplate) { Text(stringResource(R.string.save_template_label), fontFamily = GaeguRegular) }
+            TextButton(
+                onClick = onEdit,
+                colors = ButtonDefaults.textButtonColors(containerColor = buttonBackground, contentColor = textColor)
+            ) {
+                Text(stringResource(R.string.edit_label), style = TextStyle(fontFamily = GaeguRegular, fontSize = 14.sp))
+            }
+            TextButton(
+                onClick = onPlan,
+                colors = ButtonDefaults.textButtonColors(containerColor = buttonBackground, contentColor = textColor)
+            ) {
+                Text(stringResource(R.string.plan_label), style = TextStyle(fontFamily = GaeguRegular, fontSize = 14.sp))
+            }
+            TextButton(
+                onClick = onSaveTemplate,
+                colors = ButtonDefaults.textButtonColors(containerColor = buttonBackground, contentColor = textColor)
+            ) {
+                Text(stringResource(R.string.save_template_label), style = TextStyle(fontFamily = GaeguRegular, fontSize = 14.sp))
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LineParagraphPage.kt
@@ -2,8 +2,6 @@ package com.example.mygymapp.ui.pages
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -18,6 +16,7 @@ import com.example.mygymapp.model.Line
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.store.JournalStore
 import com.example.mygymapp.ui.components.PaperBackground
+import com.example.mygymapp.ui.components.GaeguButton
 import com.example.mygymapp.R
 
 @Composable
@@ -50,7 +49,11 @@ fun LineParagraphPage(
             .imePadding()
     ) {
         Column(Modifier.fillMaxSize()) {
-            TabRow(selectedTabIndex = selectedTab) {
+            TabRow(
+                selectedTabIndex = selectedTab,
+                modifier = Modifier.padding(vertical = 8.dp),
+                containerColor = Color.Transparent
+            ) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
                         selected = selectedTab == index,
@@ -91,7 +94,8 @@ fun LineParagraphPage(
             }
 
             Spacer(modifier = Modifier.height(16.dp))
-            Button(
+            GaeguButton(
+                text = if (selectedTab == 0) stringResource(R.string.compose_new_line_button) else stringResource(R.string.add_paragraph_button),
                 onClick = {
                     if (selectedTab == 0) {
                         editingLine = null
@@ -100,18 +104,12 @@ fun LineParagraphPage(
                         navController.navigate("paragraph_editor")
                     }
                 },
+                textColor = Color.Black,
                 modifier = Modifier
                     .padding(horizontal = 24.dp)
                     .fillMaxWidth()
-                    .navigationBarsPadding(),
-                shape = MaterialTheme.shapes.medium
-            ) {
-                Text(
-                    text = if (selectedTab == 0) stringResource(R.string.compose_new_line_button) else stringResource(R.string.add_paragraph_button),
-                    fontFamily = GaeguRegular,
-                    color = Color.Black
-                )
-            }
+                    .navigationBarsPadding()
+            )
             Spacer(modifier = Modifier.height(16.dp))
         }
     }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/LinesPage.kt
@@ -3,18 +3,29 @@ package com.example.mygymapp.ui.pages
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.ui.graphics.Color
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.mygymapp.R
 import com.example.mygymapp.model.Line
+import com.example.mygymapp.ui.components.FilterChips
+import com.example.mygymapp.ui.components.GaeguButton
 import com.example.mygymapp.ui.components.LineCard
 import com.example.mygymapp.ui.components.PaperBackground
-import com.example.mygymapp.R
+import com.example.mygymapp.ui.components.PoeticDivider
+import com.example.mygymapp.ui.components.PoeticMultiSelectChips
+import com.example.mygymapp.ui.pages.GaeguRegular
 
 @Composable
 fun LinesPage(
@@ -25,35 +36,115 @@ fun LinesPage(
     onManageExercises: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var search by remember { mutableStateOf("") }
+    var selectedCategory by remember { mutableStateOf<String?>(null) }
+    val selectedMuscles = remember { mutableStateListOf<String>() }
+
+    val query = search.trim().lowercase()
+    val filtered = lines.filter { line ->
+        val matchesCategory = selectedCategory == null || line.category == selectedCategory
+        val matchesMuscle = selectedMuscles.isEmpty() || selectedMuscles.contains(line.muscleGroup)
+        val matchesSearch = line.title.lowercase().contains(query)
+        matchesCategory && matchesMuscle && matchesSearch
+    }
+
+    val inkColor = Color(0xFF1B1B1B)
+
     PaperBackground(modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize()) {
             TextButton(
-                onClick = onAdd,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 8.dp)
-            ) {
-                Text(stringResource(R.string.write_new_line), fontFamily = GaeguRegular, color = Color.Black)
-            }
-            TextButton(
                 onClick = onManageExercises,
-                modifier = Modifier.align(Alignment.End)
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(horizontal = 24.dp, vertical = 8.dp)
             ) {
                 Text(stringResource(R.string.manage_exercises), fontFamily = GaeguRegular, color = Color.Black)
             }
-            LazyColumn(
+
+            BasicTextField(
+                value = search,
+                onValueChange = { search = it },
+                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp),
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(vertical = 16.dp)
-            ) {
-                items(lines) { line ->
-                    LineCard(
-                        line = line,
-                        onEdit = { onEdit(line) },
-                        onAdd = { onAdd() },
-                        onArchive = { onArchive(line) },
-                        modifier = Modifier.padding(vertical = 6.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .drawBehind {
+                        val strokeWidth = 2f
+                        val y = size.height - strokeWidth / 2
+                        drawLine(
+                            color = inkColor,
+                            start = Offset(0f, y),
+                            end = Offset(size.width, y),
+                            strokeWidth = strokeWidth
+                        )
+                    },
+                cursorBrush = SolidColor(inkColor),
+                decorationBox = { innerTextField ->
+                    if (search.isEmpty()) {
+                        Text("Search lines…", fontFamily = GaeguRegular, color = Color.Gray)
+                    }
+                    innerTextField()
+                }
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Box(Modifier.padding(horizontal = 24.dp)) {
+                FilterChips(
+                    items = listOf("Push", "Pull", "Core", "Cardio", "Recovery"),
+                    selected = selectedCategory,
+                    onSelected = { selectedCategory = it }
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            PoeticMultiSelectChips(
+                options = listOf("Back", "Legs", "Core", "Shoulders", "Chest", "Arms", "Full Body"),
+                selectedItems = selectedMuscles,
+                onSelectionChange = { selections ->
+                    selectedMuscles.clear()
+                    selectedMuscles.addAll(selections)
+                },
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+
+            PoeticDivider(centerText = "Your saved lines")
+
+            if (filtered.isEmpty()) {
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        "No lines found.",
+                        style = TextStyle(fontFamily = GaeguRegular, fontSize = 18.sp),
+                        color = Color.Black
                     )
+                    Spacer(Modifier.height(12.dp))
+                    GaeguButton(
+                        text = stringResource(R.string.compose_new_line_button),
+                        onClick = onAdd,
+                        textColor = Color.Black
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 16.dp)
+                ) {
+                    items(filtered) { line ->
+                        LineCard(
+                            line = line,
+                            onEdit = { onEdit(line) },
+                            onAdd = onAdd,
+                            onArchive = { onArchive(line) },
+                            modifier = Modifier.padding(vertical = 6.dp, horizontal = 24.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphsPage.kt
+++ b/app/src/main/java/com/example/mygymapp/ui/pages/ParagraphsPage.kt
@@ -1,151 +1,30 @@
 package com.example.mygymapp.ui.pages
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Divider
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.mygymapp.R
 import com.example.mygymapp.model.Paragraph
 import com.example.mygymapp.model.PlannedParagraph
+import com.example.mygymapp.ui.components.GaeguButton
 import com.example.mygymapp.ui.components.PaperBackground
-import com.example.mygymapp.ui.components.PoeticCard
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-fun ParagraphEntryCard(
-    paragraph: Paragraph,
-    onEdit: () -> Unit,
-    onPlan: () -> Unit,
-    onSaveTemplate: () -> Unit,
-    onArchive: () -> Unit,
-    modifier: Modifier = Modifier,
-    showButtons: Boolean = true,
-    startDate: String? = null,
-    onPreview: () -> Unit = {},
-) {
-    PoeticCard(
-        modifier = modifier
-            .padding(horizontal = 24.dp)
-            .combinedClickable(onClick = {}, onLongClick = onPreview)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = paragraph.title,
-                style = TextStyle(fontFamily = GaeguBold, fontSize = 22.sp, color = Color.Black)
-            )
-        }
-        if (startDate != null) {
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = "Starts on: $startDate",
-                style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.DarkGray)
-            )
-        }
-        Spacer(Modifier.height(4.dp))
-        val days = listOf(
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Sunday",
-        )
-        paragraph.lineTitles.forEachIndexed { index, title ->
-            if (title.isNotBlank()) {
-                Row {
-                    Text(
-                        text = days.getOrNull(index) ?: "Day ${index + 1}",
-                        style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
-                    )
-                    Text(
-                        text = " \u2192 ",
-                        style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
-                    )
-                    Text(
-                        text = title,
-                        style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.Black)
-                    )
-                }
-            }
-        }
-        if (paragraph.note.isNotBlank()) {
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = paragraph.note,
-                style = TextStyle(
-                    fontFamily = GaeguRegular,
-                    fontSize = 14.sp,
-                    fontStyle = FontStyle.Italic,
-                    color = Color.Gray,
-                )
-            )
-        }
-        if (showButtons) {
-            Spacer(Modifier.height(8.dp))
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                TextButton(onClick = onEdit, modifier = Modifier.weight(1f)) {
-                    Text(
-                        "\u270F Edit",
-                        fontFamily = GaeguRegular,
-                        color = Color.Black,
-                        fontSize = 14.sp,
-                        maxLines = 1,
-                    )
-                }
-                TextButton(onClick = onPlan, modifier = Modifier.weight(1f)) {
-                    Text(
-                        "\uD83D\uDCC6 Plan",
-                        fontFamily = GaeguRegular,
-                        color = Color.Black,
-                        fontSize = 14.sp,
-                        maxLines = 1,
-                    )
-                }
-                TextButton(onClick = onSaveTemplate, modifier = Modifier.weight(1f)) {
-                    Text(
-                        "\uD83D\uDCC3 Save",
-                        fontFamily = GaeguRegular,
-                        color = Color.Black,
-                        fontSize = 14.sp,
-                        maxLines = 1,
-                    )
-                }
-                TextButton(onClick = onArchive, modifier = Modifier.weight(1f)) {
-                    Text(
-                        "\uD83D\uDCC1 Archive",
-                        fontFamily = GaeguRegular,
-                        color = Color.Black,
-                        fontSize = 14.sp,
-                        maxLines = 1,
-                    )
-                }
-            }
-        }
-    }
-}
+import com.example.mygymapp.ui.components.PoeticDivider
+import com.example.mygymapp.ui.components.ParagraphCard
+import com.example.mygymapp.ui.pages.GaeguRegular
 
-/**
- * Displays a poetic list of paragraphs with tabs for active and archived entries.
- */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ParagraphsPage(
     paragraphs: List<Paragraph>,
@@ -156,122 +35,75 @@ fun ParagraphsPage(
     onSaveTemplate: (Paragraph) -> Unit,
     onArchive: (Paragraph) -> Unit,
     onAdd: () -> Unit,
-    onPreview: (Paragraph) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    var selectedTab by remember { mutableStateOf(0) }
-    val tabs = listOf("Active", "Archived")
+    var search by remember { mutableStateOf("") }
+    val query = search.trim().lowercase()
+    val filtered = paragraphs.filter { it.title.lowercase().contains(query) }
+    val inkColor = Color(0xFF1B1B1B)
 
-    PaperBackground(modifier = modifier.fillMaxSize()) {
-        Column {
-            Column(
+    PaperBackground(modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            BasicTextField(
+                value = search,
+                onValueChange = { search = it },
+                textStyle = TextStyle(fontFamily = GaeguRegular, fontSize = 20.sp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    text = "\uD83D\uDCDA Weekly Chapters",
-                    style = TextStyle(fontFamily = GaeguBold, fontSize = 24.sp, color = Color.Black)
-                )
-                Text(
-                    text = "Browse what you\u2019ve composed \u2013 week by week.",
-                    style = TextStyle(fontFamily = GaeguRegular, fontSize = 16.sp, color = Color.DarkGray)
-                )
-            }
-
-            TabRow(selectedTabIndex = selectedTab) {
-                tabs.forEachIndexed { index, title ->
-                    Tab(
-                        selected = selectedTab == index,
-                        onClick = { selectedTab = index },
-                        text = { Text(title, fontFamily = GaeguRegular, color = Color.Black) },
-                    )
+                    .padding(horizontal = 24.dp)
+                    .drawBehind {
+                        val strokeWidth = 2f
+                        val y = size.height - strokeWidth / 2
+                        drawLine(
+                            color = inkColor,
+                            start = Offset(0f, y),
+                            end = Offset(size.width, y),
+                            strokeWidth = strokeWidth
+                        )
+                    },
+                cursorBrush = SolidColor(inkColor),
+                decorationBox = { innerTextField ->
+                    if (search.isEmpty()) {
+                        Text("Search paragraphs…", fontFamily = GaeguRegular, color = Color.Gray)
+                    }
+                    innerTextField()
                 }
-            }
+            )
 
-            if (selectedTab == 0) {
-                TextButton(
-                    onClick = onAdd,
-                    modifier = Modifier
-                        .padding(top = 16.dp, bottom = 8.dp)
-                        .fillMaxWidth(),
+            PoeticDivider(centerText = "Your paragraphs")
+
+            if (filtered.isEmpty()) {
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
-                        "\u2795 Begin a new weekly paragraph",
-                        fontFamily = GaeguRegular,
-                        color = Color.Black,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
+                        "No paragraphs found.",
+                        style = TextStyle(fontFamily = GaeguRegular, fontSize = 18.sp),
+                        color = Color.Black
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    GaeguButton(
+                        text = stringResource(R.string.add_paragraph_button),
+                        onClick = onAdd,
+                        textColor = Color.Black
                     )
                 }
-
+            } else {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(bottom = 72.dp),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 16.dp)
                 ) {
-                    items(paragraphs, key = { it.id }) { paragraph ->
-                        ParagraphEntryCard(
+                    items(filtered) { paragraph ->
+                        ParagraphCard(
                             paragraph = paragraph,
                             onEdit = { onEdit(paragraph) },
                             onPlan = { onPlan(paragraph) },
                             onSaveTemplate = { onSaveTemplate(paragraph) },
-                            onArchive = { onArchive(paragraph) },
-                            modifier = Modifier
-                                .padding(vertical = 6.dp)
-                                .animateItemPlacement(),
-                            showButtons = true,
-                            onPreview = { onPreview(paragraph) },
-                        )
-                    }
-                    if (planned.isNotEmpty()) {
-                        item {
-                            Divider(
-                                color = Color.Black.copy(alpha = 0.2f),
-                                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
-                            )
-                        }
-                        item {
-                            Text(
-                                text = "\u23F3 Planned for the Future",
-                                style = TextStyle(fontFamily = GaeguBold, fontSize = 20.sp, color = Color.Black),
-                                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
-                            )
-                        }
-                        items(planned, key = { it.paragraph.id }) { plannedParagraph ->
-                            ParagraphEntryCard(
-                                paragraph = plannedParagraph.paragraph,
-                                onEdit = {},
-                                onPlan = {},
-                                onSaveTemplate = {},
-                                onArchive = {},
-                                modifier = Modifier
-                                    .padding(vertical = 6.dp)
-                                    .animateItemPlacement(),
-                                showButtons = false,
-                                startDate = plannedParagraph.startDate.toString(),
-                                onPreview = { onPreview(plannedParagraph.paragraph) },
-                            )
-                        }
-                    }
-                }
-            } else {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(bottom = 72.dp),
-                ) {
-                    items(archived, key = { it.id }) { paragraph ->
-                        ParagraphEntryCard(
-                            paragraph = paragraph,
-                            onEdit = {},
-                            onPlan = {},
-                            onSaveTemplate = {},
-                            onArchive = {},
-                            modifier = Modifier
-                                .padding(vertical = 6.dp)
-                                .animateItemPlacement(),
-                            showButtons = false,
-                            onPreview = { onPreview(paragraph) },
+                            modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp)
                         )
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,10 +134,10 @@
     <string name="add_title_and_movement_error">Please add a title and at least one movement.</string>
     <string name="write_new_line">＋ Write a new line</string>
     <string name="manage_exercises">⚙ Manage Exercises</string>
-    <string name="line_card_summary">%1$d exercises • %2$d %3$s</string>
+    <string name="line_card_summary">%1$d exercises · %2$d %3$s</string>
     <string name="superset_singular">superset</string>
     <string name="superset_plural">supersets</string>
-    <string name="note_prefix">• %1$s</string>
+    <string name="note_prefix">Note: %1$s</string>
     <string name="edit_label">✎ Edit</string>
     <string name="add_label">＋ Add</string>
     <string name="archive_label">Archive</string>


### PR DESCRIPTION
## Summary
- Calm tabbed container with parchment button CTA for lines and paragraphs
- Add search, filtering chips, and empty states to LinesPage
- Simplify paragraphs view with search, divider, and refreshed cards

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1614cd8c832ab597aa65bde70cb6